### PR TITLE
Move secondary-analysis-python code from skylab to here

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+FROM python:2.7
+
+LABEL maintainer="Mint Team <mintteam@broadinstitute.org>" \
+  software="Python" \
+  description="Python2.7 library used for processing notifications from HCA DCP and doing submissions."
+
+RUN mkdir /tools
+
+WORKDIR /tools
+
+COPY . .
+
+RUN pip install .
+
+# Install the latest hca-cli for submit.wdl
+RUN pip install hca

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include tests/data/*

--- a/README.md
+++ b/README.md
@@ -1,1 +1,0 @@
-# pipeline-tools

--- a/README.rst
+++ b/README.rst
@@ -1,0 +1,87 @@
+Overview
+========
+This package provides utilities for retrieving files from the data storage service for the Human Cell Atlas, and for
+submitting an analysis bundle to the Human Cell Atlas Data Coordination Platform.
+
+The steps in the submission process are as follows:
+
+* Create analysis.json
+* Create submission envelope and upload metadata
+* Get URN needed to stage files
+* Stage files
+* Confirm submission
+
+create_analysis_json.py
+=======================
+Creates analysis.json file.
+
+Invoke it like this::
+
+    create-analysis-json \
+      --analysis_id ${workflow_id} \
+      --metadata_json ${metadata_json} \
+      --input_bundles ${bundle_uuid} \
+      --reference_bundle ${reference_bundle} \
+      --run_type ${run_type} \
+      --method ${method} \
+      --schema_version ${schema_version} \
+      --inputs_file ${write_objects(inputs)} \
+      --outputs_file ${write_lines(outputs)} \
+      --format_map ${format_map}
+
+All arguments are required.
+
+create_envelope.py
+==================
+Creates submission envelope and uploads metadata.
+
+Invoke it like this::
+
+    create-envelope \  
+      --submit_url ${submit_url} \
+      --analysis_json_path analysis.json
+
+Both arguments are required.
+
+get_staging_urn.py
+==================
+Obtains URN needed for staging files. Queries ingest API until URN is available.
+The URN (Uniform Resource Name) is a long string that looks like this:
+hca:sta:aws:staging:{short hash}:{long hash}
+
+It gets decoded by stage.py to extract the staging location and credentials
+needed to stage files.
+
+Invoke it like this::
+
+    get-staging-urn \
+      --envelope_url ${submission_url} \
+      --retry_seconds ${retry_seconds} \
+      --timeout_seconds ${timeout_seconds} > submission_urn.txt
+
+envelope_url is required
+
+stage.py
+========
+Uploads files to staging area.
+
+Invoke it like this::
+
+    stage $local_file_path $submission_urn
+
+Both arguments are required
+
+confirm_submission.py
+=====================
+Confirms submission. This causes the ingest service to finalize the submission and create a bundle in the storage service.
+
+Waits until submission status is "Valid", since submission cannot be confirmed until then.
+
+Invoke it like this::
+
+    confirm-submission \
+      --envelope_url ${submission_url} \
+      --retry_seconds ${retry_seconds} \
+      --timeout_seconds ${timeout_seconds}
+
+envelope_url is required

--- a/pipeline_tools/confirm_submission.py
+++ b/pipeline_tools/confirm_submission.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python
+
+import requests
+import argparse
+import time
+
+def run(envelope_url, retry_seconds, timeout_seconds):
+    start = time.time()
+    while True:
+        print('Getting status for {}'.format(envelope_url))
+        envelope_js = get_envelope_json(envelope_url)
+        status = envelope_js.get('submissionState')
+        print('submissionState: {}'.format(status))
+        if status == 'Valid':
+            break
+        time.sleep(retry_seconds)
+        current = time.time()
+        if current - start >= timeout_seconds:
+            message = 'Timed out while waiting for Valid status. Timeout seconds: {}'.format(timeout_seconds)
+            raise ValueError(message)
+    confirm(envelope_url)
+
+def confirm(envelope_url):
+    print('Confirming submission')
+    headers = {
+        'Content-type': 'application/json'
+    }
+    response = requests.put('{}/submissionEvent'.format(envelope_url), headers=headers)
+    print(response.text)
+
+def get_envelope_json(envelope_url):
+    response = requests.get(envelope_url)
+    envelope_js = response.json()
+    return envelope_js
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--envelope_url', required=True)
+    parser.add_argument('--retry_seconds', type=int, default=10)
+    parser.add_argument('--timeout_seconds', type=int, default=600)
+    args = parser.parse_args()
+    run(args.envelope_url, args.retry_seconds, args.timeout_seconds)
+
+if __name__ == '__main__':
+    main()

--- a/pipeline_tools/create_analysis_json.py
+++ b/pipeline_tools/create_analysis_json.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python
+
+import json
+import argparse
+
+def create_analysis(analysis_id, metadata_file, input_bundles_string, reference_bundle,
+        run_type, method, schema_version, inputs_file, outputs_file, format_map):
+    print('Creating analysis.json for {}'.format(analysis_id))
+
+    with open(metadata_file) as f:
+        metadata = json.load(f)
+        start, end = get_start_end(metadata)
+        tasks = get_tasks(metadata)
+
+    inputs = create_inputs(inputs_file)
+    outputs = create_outputs(outputs_file, format_map)
+
+    input_bundles = get_input_bundles(input_bundles_string)
+
+    analysis = {
+        'analysis_id': analysis_id,
+        'analysis_run_type': run_type,
+        'reference_bundle': reference_bundle,
+        'computational_method': method,
+        'input_bundles': input_bundles,
+        'timestamp_start_utc': start,
+        'timestamp_stop_utc': end,
+        'metadata_schema': schema_version,
+        'tasks': tasks,
+        'inputs': inputs,
+        'outputs': outputs
+    }
+
+    return analysis
+
+def create_inputs(inputs_file):
+    inputs = []
+    with open(inputs_file) as f:
+        f.readline() # skip header
+        for line in f:
+            parts = line.strip().split('\t')
+            name = parts[0]
+            value = parts[1]
+            input = {
+                'name': name,
+                'value': value
+            }
+            if value.startswith('gs://'):
+                # This is a placeholder for now, since the analysis json schema requires it.
+                # In future we will either properly calculate a checksum for the file
+                # or remove it from the schema.
+                input['checksum'] = 'd0f7d08f1980f7980f'
+            inputs.append(input)
+    return inputs
+
+def create_outputs(outputs_file, format_map):
+    with open(format_map) as f:
+        extension_to_format = json.load(f)
+
+    outputs = []
+    with open(outputs_file) as f:
+        for line in f:
+            path = line.strip()
+            d = {
+              'file_path': path,
+              'name': path.split('/')[-1],
+              'format': get_format(path, extension_to_format)
+            }
+            outputs.append(d)
+    return outputs
+
+def get_format(path, extension_to_format):
+    for ext in extension_to_format:
+        if path.endswith(ext):
+            format = extension_to_format[ext]
+            print(format)
+            return format
+    print('Warning: no known format matches file {}'.format(path))
+    return 'unknown'
+
+def get_input_bundles(input_bundles_string):
+    input_bundles = input_bundles_string.split(',')
+    print(input_bundles)
+    return input_bundles
+
+def get_start_end(metadata):
+    start = metadata['start']
+    end = metadata['end']
+    print(start, end)
+    return start, end
+
+def get_tasks(metadata):
+    calls = metadata['calls']
+
+    out_tasks = []
+    for long_task_name in calls:
+        task_name = long_task_name.split('.')[-1]
+        task = calls[long_task_name][0]
+        runtime = task['runtimeAttributes']
+
+        out_task = {
+            'name': task_name,
+            'cpus': int(runtime['cpu']),
+            'memory': runtime['memory'],
+            'disk_size': runtime['disks'],
+            'docker_image': runtime['docker'],
+            'zone': runtime['zones'],
+            'start_time': task['start'],
+            'stop_time': task['end'],
+            'log_out': task['stdout'],
+            'log_err': task['stderr']
+        }
+        out_tasks.append(out_task)
+    sorted_out_tasks = sorted(out_tasks, key=lambda k: k['name'])
+    return sorted_out_tasks
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--analysis_id', required=True, help='Cromwell workflow id')
+    parser.add_argument('--metadata_json', required=True, help='JSON obtained from calling Cromwell metadata endpoint for this workflow id')
+    parser.add_argument('--input_bundles', required=True, help='The DSS bundles used as inputs for the workflow')
+    parser.add_argument('--reference_bundle', required=True, help='To refer to the DSS resource bundle used for this workflow, once such things exist')
+    parser.add_argument('--run_type', required=True, help='Should always be "run" for now, may be "copy-forward" in some cases in future')
+    parser.add_argument('--method', required=True, help='Supposed to be method store url, for now can be url for wdl in skylab')
+    parser.add_argument('--schema_version', required=True, help='The metadata schema version that this analysis.json conforms to')
+    parser.add_argument('--inputs_file', required=True, help='Path to tsv containing info about inputs')
+    parser.add_argument('--outputs_file', required=True, help='Path to json file containing info about outputs')
+    parser.add_argument('--format_map', required=True, help='JSON file providing map of file extensions to formats')
+    args = parser.parse_args()
+    analysis = create_analysis(args.analysis_id, args.metadata_json, args.input_bundles,
+        args.reference_bundle, args.run_type, args.method, args.schema_version,
+        args.inputs_file, args.outputs_file, args.format_map)
+    with open('analysis.json', 'w') as f:
+        json.dump(analysis, f, indent=2, sort_keys=True)
+
+if __name__ == '__main__':
+    main()

--- a/pipeline_tools/create_envelope.py
+++ b/pipeline_tools/create_envelope.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python
+
+import requests
+import json
+import argparse
+
+def run(submit_url, analysis_json_path):
+    # 1. Get envelope url
+    print('Getting envelope url from {}'.format(submit_url))
+    response = requests.get(submit_url)
+    check_status(response.status_code, response.text)
+    envelope_url = get_entity_url(response.json(), 'submissionEnvelopes')
+
+    # 2. Create envelope, get analysis and submission urls
+    print('Creating submission envelope at {0}'.format(envelope_url))
+    response = requests.post(envelope_url, '{}')
+    check_status(response.status_code, response.text)
+    envelope_js = response.json()
+    analyses_url = get_entity_url(envelope_js, 'analyses')
+    print('Creating analysis at {0}'.format(analyses_url))
+    submission_url = get_entity_url(envelope_js, 'submissionEnvelope')
+    with open('submission_url.txt', 'w') as f:
+        f.write(submission_url)
+
+    # 3. Create analysis, get input bundles url, file refs url
+    json_header = {'Content-type': 'application/json'}
+    with open(analysis_json_path) as f:
+        analysis_json_contents = json.load(f)
+    response = requests.post(analyses_url, headers=json_header, data=json.dumps(analysis_json_contents))
+    check_status(response.status_code, response.text)
+    analysis_js = response.json()
+    input_bundles_url = get_entity_url(analysis_js, 'add-input-bundles')
+    file_refs_url = get_entity_url(analysis_js, 'add-file-reference')
+
+    # 4. Add input bundles
+    print('Adding input bundles at {0}'.format(input_bundles_url))
+    input_bundle_uuid = get_input_bundle_uuid(analysis_json_contents)
+    bundle_refs_js = json.dumps({"bundleUuids": [input_bundle_uuid]}, indent=2)
+    print(bundle_refs_js)
+    response = requests.put(input_bundles_url, headers=json_header, data=bundle_refs_js)
+    check_status(response.status_code, response.text)
+
+    # 5. Add file references
+    print('Adding file references at {0}'.format(file_refs_url))
+    output_files = get_output_files(analysis_json_contents)
+    for file_ref in output_files:
+        print('Adding file: {}'.format(file_ref['fileName']))
+        response = requests.put(file_refs_url, headers=json_header, data=json.dumps(file_ref))
+        check_status(response.status_code, response.text)
+
+def check_status(status, response_text, expected='2xx'):
+    """Check that status is in range 200-299 or the specified range, if given.
+    Raises a ValueError and prints response_text if status is not in the expected range. Otherwise,
+    just returns silently.
+    Args:
+        status (int): The actual HTTP status code.
+        response_text (str): Text to print along with status code when mismatch occurs
+        expected (str): The range of acceptable values represented as a string.
+    Examples:
+        check_status(200, 'foo') passes
+        check_status(404, 'foo') raises error
+        check_status(301, 'bar') raises error
+        check_status(301, 'bar', '3xx') passes
+    """
+    first_digit = int(expected[0])
+    low = first_digit * 100
+    high = low + 99
+    matches = low <= status <= high
+    if not matches:
+        message = 'HTTP status code {0} is not in expected range {1}. Response: {2}'.format(status, expected, response_text)
+        raise ValueError(message)
+
+def get_entity_url(js, entity):
+    entity_url = js['_links'][entity]['href'].split('{')[0]
+    print('Got url for {0}: {1}'.format(entity, entity_url))
+    return entity_url
+
+def get_input_bundle_uuid(analysis_json):
+    bundle = analysis_json['input_bundles'][0]
+    uuid = bundle
+    print('Input bundle uuid {0}'.format(uuid))
+    return uuid
+
+def get_output_files(analysis_json):
+    outputs = analysis_json['outputs']
+    output_refs = []
+    for o in outputs:
+        output_ref = {}
+        file_name = o['file_path'].split('/')[-1] 
+        output_ref['fileName'] = file_name
+        output_ref['content'] = {
+            'name': file_name,
+            'format': o['format']
+        }
+        output_refs.append(output_ref)
+    return output_refs
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--submit_url', required=True)
+    parser.add_argument('--analysis_json_path', required=True)
+    args = parser.parse_args()
+    run(args.submit_url, args.analysis_json_path)
+
+if __name__ == '__main__':
+    main()

--- a/pipeline_tools/get_staging_urn.py
+++ b/pipeline_tools/get_staging_urn.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python
+
+import requests
+import argparse
+import time
+
+def run(envelope_url, retry_seconds, timeout_seconds):
+    start = time.time()
+    urn = None
+    while True:
+        envelope_js = get_envelope_json(envelope_url)
+        urn = get_staging_urn(envelope_js)
+        if urn:
+            break
+        time.sleep(retry_seconds)
+        current = time.time()
+        if current - start >= timeout_seconds:
+            message = 'Timed out while trying to get urn. Timeout seconds: {}'.format(timeout_seconds)
+            raise ValueError(message)
+    print(urn)
+
+def get_envelope_json(envelope_url):
+    response = requests.get(envelope_url)
+    envelope_js = response.json()
+    return envelope_js
+
+def get_staging_urn(envelope_js):
+    details = envelope_js.get('stagingDetails')
+    if not details:
+        return None
+    location = details.get('stagingAreaLocation')
+    if not location:
+        return None
+    urn = location.get('value')
+    return urn
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--envelope_url', required=True)
+    parser.add_argument('--retry_seconds', type=int, default=10)
+    parser.add_argument('--timeout_seconds', type=int, default=600)
+    args = parser.parse_args()
+    run(args.envelope_url, args.retry_seconds, args.timeout_seconds)
+
+if __name__ == '__main__':
+    main()

--- a/pipeline_tools/stage.py
+++ b/pipeline_tools/stage.py
@@ -1,0 +1,134 @@
+#!/usr/bin/env python
+
+"""
+Note:
+This is a slightly modified version of a script from the staging service repo here:
+https://github.com/HumanCellAtlas/staging-service/blob/master/scripts/stage_file.py
+
+It has been modified to facilitate calling it from our submission WDL.
+
+This was a short term solution for demo purposes but we don't want to keep two
+copies of this script in the long term. In future, we expect to delete this
+script because one of the following things will happen:
+1) We'll merge our changes into the staging service repo and delete this copy.
+OR
+2) More likely, future changes to the staging service will make this script unnecessary.
+
+
+Stage files in the HCA Staging Area
+
+Usage:
+
+    stage_file cp <file> <urn>
+
+"""
+
+import argparse, base64, json, os, sys
+from collections import deque
+
+try:
+    import boto3
+    from boto3.s3.transfer import TransferConfig
+except ImportError:
+    print("\nPlease install boto3 to use this script, e.g. \"pip install boto3\"\n")
+    exit(1)
+
+KB = 1024
+MB = KB * KB
+
+
+def sizeof_fmt(num, suffix='B'):
+    """
+    From https://stackoverflow.com/a/1094933
+    """
+    for unit in ['', 'Ki', 'Mi', 'Gi', 'Ti', 'Pi', 'Ei', 'Zi']:
+        if abs(num) < 1024.0:
+            return "%d %s%s" % (num, unit, suffix)
+        num /= 1024.0
+    return "%.1f %s%s" % (num, 'Yi', suffix)
+
+
+class Main:
+
+    STAGING_BUCKET_TEMPLATE = "org-humancellatlas-staging-%s"
+    CLEAR_TO_EOL = "\x1b[0K"
+
+    def __init__(self):
+        self._parse_args()
+        self._parse_urn(self.args.urn)
+        session = boto3.session.Session(**self.aws_credentials)
+        self.s3 = session.resource('s3')
+        self._stage_file(self.args.file_path)
+
+    def _parse_args(self):
+        parser = argparse.ArgumentParser(description=__doc__,
+                                         formatter_class=argparse.RawDescriptionHelpFormatter)
+        parser.add_argument('file_path', metavar="<file>",
+                            help="name of file to stage")
+        parser.add_argument('urn', metavar='<URN>',
+                            help="URN of staging area (given to you by Ingest Broker)")
+        self.args = parser.parse_args()
+
+    def _parse_urn(self, urn):
+        # TODO reimplement as deque
+        urnbits = urn.split(':')
+        if len(urnbits) == 6:
+            self.deployment_stage = urnbits[3]
+            self.area_uuid = urnbits[4]
+            encoded_credentials = urnbits[5]
+        elif len(urnbits) == 5:
+            self.deployment_stage = 'dev'
+            self.area_uuid = urnbits[3]
+            encoded_credentials = urnbits[4]
+        else:
+            raise RuntimeError("Bad URN")
+        uppercase_credentials = json.loads(base64.b64decode(encoded_credentials))
+        self.aws_credentials = {k.lower(): v for k, v in uppercase_credentials.items()}
+
+    def callback(self, bytes_transferred):
+        self.cumulative_bytes_transferred += bytes_transferred
+        percent_complete = (self.cumulative_bytes_transferred * 100) / self.file_size
+        sys.stdout.write("\r%s of %s transferred (%.0f%%)%s" %
+                         (sizeof_fmt(self.cumulative_bytes_transferred),
+                          sizeof_fmt(self.file_size),
+                          percent_complete,
+                          self.CLEAR_TO_EOL))
+        sys.stdout.flush()
+
+    def _stage_file(self, file_path):
+        print("Uploading %s to staging area %s..." % (os.path.basename(file_path), self.area_uuid))
+        self.file_size = os.stat(file_path).st_size
+        bucket_name = self.STAGING_BUCKET_TEMPLATE % (self.deployment_stage,)
+        file_s3_key = "%s/%s" % (self.area_uuid, os.path.basename(file_path))
+        bucket = self.s3.Bucket(bucket_name)
+        obj = bucket.Object(file_s3_key)
+        with open(file_path, 'rb') as fh:
+            self.cumulative_bytes_transferred = 0
+            obj.upload_fileobj(fh,
+                               ExtraArgs={'ACL': 'bucket-owner-full-control'},
+                               Callback=self.callback,
+                               Config=self.transfer_config(self.file_size)
+                               )
+        print("\n")
+
+    @classmethod
+    def transfer_config(cls, file_size):
+        etag_stride = cls._s3_chunk_size(file_size)
+        return TransferConfig(multipart_threshold=etag_stride,
+                              multipart_chunksize=etag_stride)
+
+    @staticmethod
+    def _s3_chunk_size(file_size):
+        if file_size <= 10000 * 64 * MB:
+            return 64 * MB
+        else:
+            div = file_size // 10000
+            if div * 10000 < file_size:
+                div += 1
+            return ((div + (MB-1)) // MB) * MB
+
+def run():
+    runner = Main()
+
+if __name__ == '__main__':
+    runner = Main()

--- a/pipeline_tools/utils.py
+++ b/pipeline_tools/utils.py
@@ -1,0 +1,61 @@
+import requests
+import logging
+import time
+
+
+def get_file_by_uuid(file_id, dss_url):
+    """
+    Retrieve a file from the Human Cell Atlas data storage service by its id.
+    :param str file_id: The id of the file to retrieve
+    :param str dss_url: The url for the HCA data storage service, e.g. "https://dss.staging.data.humancellatlas.org/v1"
+    :return: dict file contents
+    """
+    url = '{dss_url}/files/{file_id}?replica=gcp'.format(
+        dss_url=dss_url, file_id=file_id)
+    logging.info('GET {0}'.format(url))
+    response = requests.get(url)
+    logging.info(response.status_code)
+    logging.info(response.text)
+    return response.json()
+
+
+def get_manifest_files(bundle_uuid, bundle_version, dss_url, timeout_seconds, retry_seconds):
+    """
+    Retrieve manifest.json file for a given bundle uuid and version.
+    :param str bundle_uuid: Bundle unique id
+    :param str bundle_version: Timestamp of bundle creation, e.g. "2017-10-23T17:50:26.894Z"
+    :param str dss_url: The url for the Human Cell Atlas data storage service, e.g. "https://dss.staging.data.humancellatlas.org/v1"
+    :param int timeout_seconds: Seconds before allowing the request to timeout
+    :param int retry_seconds: Seconds between retrying the request to get the manifest file
+    :return: {
+                'name_to_meta': dict mapping <str file name>: <dict file metadata>,
+                'url_to_name': dict mapping <str file url>: <str file name>
+             }
+    """
+    url = '{dss_url}/bundles/{bundle_uuid}?version={bundle_version}&replica=gcp&directurls=true'.format(
+        dss_url=dss_url, bundle_uuid=bundle_uuid, bundle_version=bundle_version)
+    start = time.time()
+    current = start
+    # Retry in a loop because of intermittent 5xx errors from dss
+    while current - start < timeout_seconds:
+        logging.info('GET {0}'.format(url))
+        response = requests.get(url)
+        logging.info(response.status_code)
+        logging.info(response.text)
+        if 200 <= response.status_code <= 299:
+            break
+        time.sleep(retry_seconds)
+        current = time.time()
+    manifest = response.json()
+
+    bundle = manifest['bundle']
+    name_to_meta = {}
+    url_to_name = {}
+    for f in bundle['files']:
+        name_to_meta[f['name']] = f
+        url_to_name[f['url']] = f['name']
+
+    return {
+        'name_to_meta': name_to_meta,
+        'url_to_name': url_to_name
+    }

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,25 @@
+from setuptools import setup
+
+setup(name='pipeline-tools',
+      version='1.0.0.dev1',
+      description='Utilities for retrieving files from the HCA data storage service and submitting an analysis bundle to HCA-DCP',
+      url='http://github.com/HumanCellAtlas/skylab',
+      author='Human Cell Atlas Data Coordination Platform Mint Team',
+      author_email='mintteam@broadinstitute.org',
+      license='BSD 3-clause "New" or "Revised" License',
+      packages=['pipeline_tools', 'tests'],
+      install_requires=[
+          'requests',
+          'boto3'
+      ],
+      entry_points={
+          "console_scripts": [
+              'create-analysis-json=pipeline_tools.create_analysis_json:main',
+              'create-envelope=pipeline_tools.create_envelope:main',
+              'get-staging-urn=pipeline_tools.get_staging_urn:main',
+              'stage=pipeline_tools.stage:run',
+              'confirm-submission=pipeline_tools.confirm_submission:main'
+          ]
+      },
+      include_package_data=True
+      )

--- a/tests/data/analysis.json
+++ b/tests/data/analysis.json
@@ -1,0 +1,77 @@
+{
+   "input_bundles" : [ "75a7f618-9adc-48af-a249-0010305160f6" ],
+   "inputs" : [
+      {
+        "name": "left_sample",
+        "checksum" : "d0f7d08f1980f7980f",
+        "value" : "bluebox://23bd7eb0-23a3-4898-b043-f7e982de281f/v1/12bd7eb0-23a3-4898-b043-f7e982de281g/v1#10x_R1.fastq.gz"
+      },
+      {
+         "name" : "right_sample",
+         "checksum" : "d0f7d18f7980f7980f",
+         "value" : "bluebox://23bd7eb0-23a3-4898-b043-f7e982de281f/v1/01bd7eb0-23a3-4898-b043-f7e982de281g/v1#10x_R2.fastq.gz"
+      },
+      {
+         "name" : "index_sample",
+         "checksum" : "d0f7d18f7980f7980f",
+         "value" : "bluebox://23bd7eb0-23a3-4898-b043-f7e982de281f/v1/01bd7eb0-23a3-4898-b043-f7e982de281g/v1#10x_I1.fastq.gz"
+      },
+      {
+         "name" : "expected_cell_count",
+         "value" : "1000"
+      }
+   ],
+   "timestamp_start_utc" : "2017-05-18T03:44:23-5:00",
+   "timestamp_stop_utc" : "2017-05-18T014:44:23-5:00",
+   "computational_method" : "https://www.dockstore.org:8443/api/ga4gh/v1/tools/quay.io%2Fhca%2Fdockstore-hca-uploader/",
+   "analysis_id" : 4342342,
+   "analysis_run_type" : "run",
+   "outputs" : [
+      {
+          "name": "aligned_bam",
+          "checksum" : "d0f7d08f7980f7910f",
+          "file_path" : "gs://43bd7eb0-23a3-4898-b043-f7e982de281a/v1/sample.bam",
+          "format" : "bam"
+      },
+      {
+          "name": "counts_matrix",
+          "checksum" : "d0f7d08f7910f7980f",
+          "format" : "counts_matrix",
+          "file_path" : "gs://43bd7eb0-23a3-4898-b043-f7e982de281a/v1/sample_counts.txt"
+      },
+      {
+          "name": "report_qc",
+          "format" : "qc_matrix",
+          "file_path" : "gs://43bd7eb0-23a3-4898-b043-f7e982de281a/v1/sample_qc.txt",
+          "checksum" : "d0f7d18f7980f7980f"
+      }
+   ],
+   "metadata_schema" : "version_232",
+   "tasks" : [
+      {
+       "stop_time" : "2017-05-18T08:44:23-5:00",
+       "start_time" : "2017-05-18T03:44:23-5:00",
+       "name" : "step_one",
+       "log_err" : "bluebox://43bd7eb0-23a3-4898-b043-f7e982de281a/v1/05bd7eb0-23a3-4898-b043-f7e982de281g/v1#10xv2_step_one.err",
+       "log_out" : "bluebox://43bd7eb0-23a3-4898-b043-f7e982de281a/v1/05bd7eb0-23a3-4898-b043-f7e982de281g/v1#10xv2_step_one.out",
+       "disk_size" : "500GB",
+       "docker_image" : "https://uri-to-docker-image",
+       "cpus" : 8,
+       "memory" : "10GB",
+       "zone" : "us-east4-a"
+      },
+      {
+       "start_utc" : "2017-05-18T08:44:23-5:00",
+       "stop_utc" : "2017-05-18T14:44:23-5:00",
+       "name" : "step_two",
+       "log_err" : "bluebox://43bd7eb0-23a3-4898-b043-f7e982de281a/v1/05bd7eb0-23a3-4898-b043-f7e982de281g/v1#10xv2_step_two.err",
+       "log_out" : "bluebox://43bd7eb0-23a3-4898-b043-f7e982de281a/v1/05bd7eb0-23a3-4898-b043-f7e982de281g/v1#10xv2_step_two.out",
+       "disk_size" : "500GB",
+       "docker_image" : "https://uri-to-docker-image",
+       "cpus" : 8,
+       "memory" : "10GB",
+       "zone" : "us-east4-a"
+      }
+   ],
+   "reference_bundle" : "bluebox://03gh7eb0-23a3-4898-b043-f7e982de281b/v1"
+}

--- a/tests/data/format_map.json
+++ b/tests/data/format_map.json
@@ -1,0 +1,4 @@
+{
+  ".bam": "bam",
+  "_metrics": "metrics"
+}

--- a/tests/data/inputs.tsv
+++ b/tests/data/inputs.tsv
@@ -1,0 +1,5 @@
+name	value
+fastq_read1	gs://broad-dsde-mint-dev-teststorage/path/read1.fastq.gz
+fastq_read2	gs://broad-dsde-mint-dev-teststorage/path/read2.fastq.gz
+output_prefix	GSM1957573
+test_int	123

--- a/tests/data/metadata.json
+++ b/tests/data/metadata.json
@@ -1,0 +1,413 @@
+{
+  "workflowName": "Ss2RsemSingleSample",
+  "calls": {
+    "ss2.Ss2RsemSingleSample.Star": [{
+      "executionStatus": "Done",
+      "stdout": "gs://foo/call-Star/Star-stdout.log",
+      "shardIndex": -1,
+      "outputs": {
+        "output_bam": "gs://foo/call-Star/Aligned.sortedByCoord.out.bam",
+        "junction_table": "gs://foo/call-Star/SJ.out.tab",
+        "output_bam_trans": "gs://foo/call-Star/Aligned.toTranscriptome.out.bam"
+      },
+      "runtimeAttributes": {
+        "preemptible": "0",
+        "failOnStderr": "false",
+        "bootDiskSizeGb": "10",
+        "disks": "local-disk 100 HDD",
+        "continueOnReturnCode": "0",
+        "docker": "humancellatlas/star:2.5.3a",
+        "cpu": "1",
+        "noAddress": "false",
+        "zones": "us-central1-b",
+        "memory": "40 GB"
+      },
+      "callCaching": {
+        "allowResultReuse": true,
+        "effectiveCallCachingMode": "ReadAndWriteCache",
+        "hit": true,
+        "result": "Cache Hit: 2645c220-04f6-48f7-8ff6-f8e28f9a5cae:prep_and_analyze.ss2.Ss2RsemSingleSample.Star:-1"
+      },
+      "inputs": {
+        "input_fastq_read2": "gs://org-humancellatlas-dss-dev/blobs/c0d11199740a66150b8bb70a0474d8de9819e77f3f77b55dd04790e3fe6fb53c.bb5c8a68c155bad257cb7b93faef71a116cecba2.fb9bbafee8a92ced414b3658b1bb9517.942cd9d6",
+        "input_fastq_read1": "gs://org-humancellatlas-dss-dev/blobs/9b4c0dde8683f924975d0867903dc7a967f46bee5c0a025c451b9ba73e43f120.58f03f7c6c0887baa54da85db5c820cfbe25d367.89f6f8bec37ec1fc4560f3f99d47721d.e978e85d",
+        "gtf": "gs://foo/reference/Hg19_kco/Gencode_v19/Gencode_v19.GTF",
+        "star_genome": "gs://foo/reference/Hg19_kco/star_hg19_gencode_v19.tar.gz"
+      },
+      "returnCode": 0,
+      "backend": "JES",
+      "end": "2017-09-14T19:54:22.467Z",
+      "stderr": "gs://foo/call-Star/Star-stderr.log",
+      "callRoot": "gs://foo/call-Star",
+      "attempt": 1,
+      "executionEvents": [{
+        "startTime": "2017-09-14T19:54:13.934Z",
+        "description": "BackendIsCopyingCachedOutputs",
+        "endTime": "2017-09-14T19:54:20.825Z"
+      }, {
+        "startTime": "2017-09-14T19:54:13.512Z",
+        "description": "Pending",
+        "endTime": "2017-09-14T19:54:13.512Z"
+      }, {
+        "startTime": "2017-09-14T19:54:21.500Z",
+        "description": "UpdatingJobStore",
+        "endTime": "2017-09-14T19:54:22.467Z"
+      }, {
+        "startTime": "2017-09-14T19:54:13.512Z",
+        "description": "PreparingJob",
+        "endTime": "2017-09-14T19:54:13.529Z"
+      }, {
+        "startTime": "2017-09-14T19:54:20.825Z",
+        "description": "UpdatingCallCache",
+        "endTime": "2017-09-14T19:54:21.500Z"
+      }, {
+        "startTime": "2017-09-14T19:54:13.529Z",
+        "description": "CheckingCallCache",
+        "endTime": "2017-09-14T19:54:13.930Z"
+      }, {
+        "startTime": "2017-09-14T19:54:13.930Z",
+        "description": "FetchingCachedOutputsFromDatabase",
+        "endTime": "2017-09-14T19:54:13.934Z"
+      }, {
+        "startTime": "2017-09-14T19:54:13.512Z",
+        "description": "RequestingExecutionToken",
+        "endTime": "2017-09-14T19:54:13.512Z"
+      }],
+      "backendLogs": {
+        "log": "gs://foo/call-Star/Star.log"
+      },
+      "start": "2017-09-14T19:54:13.512Z"
+    }],
+    "ss2.Ss2RsemSingleSample.CollectAlignmentSummaryMetrics": [{
+      "executionStatus": "Done",
+      "stdout": "gs://foo/call-CollectAlignmentSummaryMetrics/CollectAlignmentSummaryMetrics-stdout.log",
+      "shardIndex": -1,
+      "outputs": {
+        "alignment_metrics": "gs://foo/call-CollectAlignmentSummaryMetrics/GSM1957573_alignment_metrics"
+      },
+      "runtimeAttributes": {
+        "preemptible": "0",
+        "failOnStderr": "false",
+        "bootDiskSizeGb": "10",
+        "disks": "local-disk 10 HDD",
+        "continueOnReturnCode": "0",
+        "docker": "humancellatlas/picard:2.10.10",
+        "cpu": "1",
+        "noAddress": "false",
+        "zones": "us-central1-b",
+        "memory": "10 GB"
+      },
+      "callCaching": {
+        "allowResultReuse": true,
+        "effectiveCallCachingMode": "ReadAndWriteCache",
+        "hit": true,
+        "result": "Cache Hit: 2645c220-04f6-48f7-8ff6-f8e28f9a5cae:prep_and_analyze.ss2.Ss2RsemSingleSample.CollectAlignmentSummaryMetrics:-1"
+      },
+      "inputs": {
+        "ref_genome_fasta": "gs://foo/reference/Hg19_kco/Hg19.fa",
+        "aligned_bam": "gs://foo/call-Star/Aligned.sortedByCoord.out.bam",
+        "output_filename": "GSM1957573_alignment_metrics"
+      },
+      "returnCode": 0,
+      "backend": "JES",
+      "end": "2017-09-14T19:54:31.473Z",
+      "stderr": "gs://foo/call-CollectAlignmentSummaryMetrics/CollectAlignmentSummaryMetrics-stderr.log",
+      "callRoot": "gs://foo/call-CollectAlignmentSummaryMetrics",
+      "attempt": 1,
+      "executionEvents": [{
+        "startTime": "2017-09-14T19:54:25.401Z",
+        "description": "BackendIsCopyingCachedOutputs",
+        "endTime": "2017-09-14T19:54:29.870Z"
+      }, {
+        "startTime": "2017-09-14T19:54:25.397Z",
+        "description": "FetchingCachedOutputsFromDatabase",
+        "endTime": "2017-09-14T19:54:25.401Z"
+      }, {
+        "startTime": "2017-09-14T19:54:22.691Z",
+        "description": "Pending",
+        "endTime": "2017-09-14T19:54:22.691Z"
+      }, {
+        "startTime": "2017-09-14T19:54:29.870Z",
+        "description": "UpdatingCallCache",
+        "endTime": "2017-09-14T19:54:30.505Z"
+      }, {
+        "startTime": "2017-09-14T19:54:22.692Z",
+        "description": "PreparingJob",
+        "endTime": "2017-09-14T19:54:22.720Z"
+      }, {
+        "startTime": "2017-09-14T19:54:22.720Z",
+        "description": "CheckingCallCache",
+        "endTime": "2017-09-14T19:54:25.397Z"
+      }, {
+        "startTime": "2017-09-14T19:54:22.691Z",
+        "description": "RequestingExecutionToken",
+        "endTime": "2017-09-14T19:54:22.692Z"
+      }, {
+        "startTime": "2017-09-14T19:54:30.505Z",
+        "description": "UpdatingJobStore",
+        "endTime": "2017-09-14T19:54:31.473Z"
+      }],
+      "backendLogs": {
+        "log": "gs://foo/call-CollectAlignmentSummaryMetrics/CollectAlignmentSummaryMetrics.log"
+      },
+      "start": "2017-09-14T19:54:22.691Z"
+    }],
+    "ss2.Ss2RsemSingleSample.FeatureCountsUniqueMapping": [{
+      "executionStatus": "Done",
+      "stdout": "gs://foo/call-FeatureCountsUniqueMapping/FeatureCountsUniqueMapping-stdout.log",
+      "shardIndex": -1,
+      "outputs": {
+        "exons": "gs://foo/call-FeatureCountsUniqueMapping/GSM1957573.exon.counts.txt",
+        "genes": "gs://foo/call-FeatureCountsUniqueMapping/GSM1957573.gene.counts.txt",
+        "trans": "gs://foo/call-FeatureCountsUniqueMapping/GSM1957573.transcripts.counts.txt"
+      },
+      "runtimeAttributes": {
+        "preemptible": "0",
+        "failOnStderr": "false",
+        "bootDiskSizeGb": "10",
+        "disks": "local-disk 50 HDD",
+        "continueOnReturnCode": "0",
+        "docker": "humancellatlas/star:2.5.3a",
+        "cpu": "1",
+        "noAddress": "false",
+        "zones": "us-central1-b",
+        "memory": "10 GB"
+      },
+      "callCaching": {
+        "allowResultReuse": true,
+        "effectiveCallCachingMode": "ReadAndWriteCache",
+        "hit": true,
+        "result": "Cache Hit: 00fc9aed-0918-4dc2-9195-a6e913e737e9:ss2.Ss2RsemSingleSample.FeatureCountsUniqueMapping:-1"
+      },
+      "inputs": {
+        "gtf": "gs://foo/reference/Hg19_kco/Gencode_v19/Gencode_v19.GTF",
+        "aligned_bam": "gs://foo/call-Star/Aligned.sortedByCoord.out.bam",
+        "fc_out": "GSM1957573"
+      },
+      "returnCode": 0,
+      "backend": "JES",
+      "end": "2017-09-14T19:54:31.473Z",
+      "stderr": "gs://foo/call-FeatureCountsUniqueMapping/FeatureCountsUniqueMapping-stderr.log",
+      "callRoot": "gs://foo/call-FeatureCountsUniqueMapping",
+      "attempt": 1,
+      "executionEvents": [{
+        "startTime": "2017-09-14T19:54:24.022Z",
+        "description": "FetchingCachedOutputsFromDatabase",
+        "endTime": "2017-09-14T19:54:24.026Z"
+      }, {
+        "startTime": "2017-09-14T19:54:24.026Z",
+        "description": "BackendIsCopyingCachedOutputs",
+        "endTime": "2017-09-14T19:54:29.870Z"
+      }, {
+        "startTime": "2017-09-14T19:54:22.692Z",
+        "description": "RequestingExecutionToken",
+        "endTime": "2017-09-14T19:54:22.692Z"
+      }, {
+        "startTime": "2017-09-14T19:54:22.691Z",
+        "description": "Pending",
+        "endTime": "2017-09-14T19:54:22.692Z"
+      }, {
+        "startTime": "2017-09-14T19:54:30.505Z",
+        "description": "UpdatingJobStore",
+        "endTime": "2017-09-14T19:54:31.473Z"
+      }, {
+        "startTime": "2017-09-14T19:54:29.870Z",
+        "description": "UpdatingCallCache",
+        "endTime": "2017-09-14T19:54:30.505Z"
+      }, {
+        "startTime": "2017-09-14T19:54:22.715Z",
+        "description": "CheckingCallCache",
+        "endTime": "2017-09-14T19:54:24.022Z"
+      }, {
+        "startTime": "2017-09-14T19:54:22.692Z",
+        "description": "PreparingJob",
+        "endTime": "2017-09-14T19:54:22.715Z"
+      }],
+      "backendLogs": {
+        "log": "gs://foo/call-FeatureCountsUniqueMapping/FeatureCountsUniqueMapping.log"
+      },
+      "start": "2017-09-14T19:54:22.691Z"
+    }],
+    "ss2.Ss2RsemSingleSample.RsemExpression": [{
+      "executionStatus": "Done",
+      "stdout": "gs://foo/call-RsemExpression/RsemExpression-stdout.log",
+      "shardIndex": -1,
+      "outputs": {
+        "rsem_transc": "gs://foo/call-RsemExpression/GSM1957573.isoforms.results",
+        "rsem_gene": "gs://foo/call-RsemExpression/GSM1957573.genes.results",
+        "rsem_gene_count": "gs://foo/call-RsemExpression/GSM1957573.gene.expected_counts"
+      },
+      "runtimeAttributes": {
+        "preemptible": "0",
+        "failOnStderr": "false",
+        "bootDiskSizeGb": "10",
+        "disks": "local-disk 100 HDD",
+        "continueOnReturnCode": "0",
+        "docker": "humancellatlas/rsem:v1.3.0",
+        "cpu": "1",
+        "noAddress": "false",
+        "zones": "us-central1-b",
+        "memory": "10 GB"
+      },
+      "callCaching": {
+        "allowResultReuse": true,
+        "effectiveCallCachingMode": "ReadAndWriteCache",
+        "hit": true,
+        "result": "Cache Hit: 2645c220-04f6-48f7-8ff6-f8e28f9a5cae:prep_and_analyze.ss2.Ss2RsemSingleSample.RsemExpression:-1"
+      },
+      "inputs": {
+        "rsem_genome": "gs://foo/reference/Hg19_kco/rsem_hg19_gencode_v19.tar.gz",
+        "trans_aligned_bam": "gs://foo/call-Star/Aligned.toTranscriptome.out.bam",
+        "rsem_out": "GSM1957573"
+      },
+      "returnCode": 0,
+      "backend": "JES",
+      "end": "2017-09-14T19:54:31.473Z",
+      "stderr": "gs://foo/call-RsemExpression/RsemExpression-stderr.log",
+      "callRoot": "gs://foo/call-RsemExpression",
+      "attempt": 1,
+      "executionEvents": [{
+        "startTime": "2017-09-14T19:54:22.691Z",
+        "description": "RequestingExecutionToken",
+        "endTime": "2017-09-14T19:54:22.692Z"
+      }, {
+        "startTime": "2017-09-14T19:54:22.722Z",
+        "description": "CheckingCallCache",
+        "endTime": "2017-09-14T19:54:24.969Z"
+      }, {
+        "startTime": "2017-09-14T19:54:30.505Z",
+        "description": "UpdatingJobStore",
+        "endTime": "2017-09-14T19:54:31.473Z"
+      }, {
+        "startTime": "2017-09-14T19:54:22.691Z",
+        "description": "Pending",
+        "endTime": "2017-09-14T19:54:22.691Z"
+      }, {
+        "description": "PreparingJob",
+        "endTime": "2017-09-14T19:54:22.722Z",
+        "startTime": "2017-09-14T19:54:22.692Z"
+      }, {
+        "startTime": "2017-09-14T19:54:29.870Z",
+        "description": "UpdatingCallCache",
+        "endTime": "2017-09-14T19:54:30.505Z"
+      }, {
+        "startTime": "2017-09-14T19:54:24.973Z",
+        "description": "BackendIsCopyingCachedOutputs",
+        "endTime": "2017-09-14T19:54:29.870Z"
+      }, {
+        "startTime": "2017-09-14T19:54:24.969Z",
+        "description": "FetchingCachedOutputsFromDatabase",
+        "endTime": "2017-09-14T19:54:24.973Z"
+      }],
+      "backendLogs": {
+        "log": "gs://foo/call-RsemExpression/RsemExpression.log"
+      },
+      "start": "2017-09-14T19:54:22.691Z"
+    }],
+    "ss2.Ss2RsemSingleSample.CollectRnaSeqMetrics": [{
+      "executionStatus": "Done",
+      "stdout": "gs://foo/call-CollectRnaSeqMetrics/CollectRnaSeqMetrics-stdout.log",
+      "shardIndex": -1,
+      "outputs": {
+        "rna_metrics": "gs://foo/call-CollectRnaSeqMetrics/GSM1957573_rna_metrics"
+      },
+      "runtimeAttributes": {
+        "preemptible": "0",
+        "failOnStderr": "false",
+        "bootDiskSizeGb": "10",
+        "disks": "local-disk 10 HDD",
+        "continueOnReturnCode": "0",
+        "docker": "humancellatlas/picard:2.10.10",
+        "cpu": "1",
+        "noAddress": "false",
+        "zones": "us-central1-b",
+        "memory": "10 GB"
+      },
+      "callCaching": {
+        "allowResultReuse": true,
+        "effectiveCallCachingMode": "ReadAndWriteCache",
+        "hit": true,
+        "result": "Cache Hit: 2645c220-04f6-48f7-8ff6-f8e28f9a5cae:prep_and_analyze.ss2.Ss2RsemSingleSample.CollectRnaSeqMetrics:-1"
+      },
+      "inputs": {
+        "rrna_interval": "gs://foo/reference/Hg19_kco/hg19.rRNA.interval_list",
+        "ref_flat": "gs://foo/reference/Hg19_kco/refFlat.txt",
+        "output_filename": "GSM1957573_rna_metrics",
+        "ref_genome_fasta": "gs://foo/reference/Hg19_kco/Hg19.fa",
+        "aligned_bam": "gs://foo/call-Star/Aligned.sortedByCoord.out.bam"
+      },
+      "returnCode": 0,
+      "backend": "JES",
+      "end": "2017-09-14T19:54:31.473Z",
+      "stderr": "gs://foo/call-CollectRnaSeqMetrics/CollectRnaSeqMetrics-stderr.log",
+      "callRoot": "gs://foo/call-CollectRnaSeqMetrics",
+      "attempt": 1,
+      "executionEvents": [{
+        "startTime": "2017-09-14T19:54:30.505Z",
+        "description": "UpdatingJobStore",
+        "endTime": "2017-09-14T19:54:31.473Z"
+      }, {
+        "startTime": "2017-09-14T19:54:25.093Z",
+        "description": "FetchingCachedOutputsFromDatabase",
+        "endTime": "2017-09-14T19:54:25.098Z"
+      }, {
+        "startTime": "2017-09-14T19:54:22.692Z",
+        "description": "PreparingJob",
+        "endTime": "2017-09-14T19:54:22.720Z"
+      }, {
+        "startTime": "2017-09-14T19:54:29.508Z",
+        "description": "UpdatingCallCache",
+        "endTime": "2017-09-14T19:54:30.505Z"
+      }, {
+        "startTime": "2017-09-14T19:54:25.098Z",
+        "description": "BackendIsCopyingCachedOutputs",
+        "endTime": "2017-09-14T19:54:29.508Z"
+      }, {
+        "startTime": "2017-09-14T19:54:22.691Z",
+        "description": "RequestingExecutionToken",
+        "endTime": "2017-09-14T19:54:22.692Z"
+      }, {
+        "startTime": "2017-09-14T19:54:22.691Z",
+        "description": "Pending",
+        "endTime": "2017-09-14T19:54:22.691Z"
+      }, {
+        "startTime": "2017-09-14T19:54:22.720Z",
+        "description": "CheckingCallCache",
+        "endTime": "2017-09-14T19:54:25.093Z"
+      }],
+      "backendLogs": {
+        "log": "gs://foo/call-CollectRnaSeqMetrics/CollectRnaSeqMetrics.log"
+      },
+      "start": "2017-09-14T19:54:22.691Z"
+    }]
+  },
+  "outputs": {
+    "Ss2RsemSingleSample.exon_unique_counts": "gs://foo/call-FeatureCountsUniqueMapping/GSM1957573.exon.counts.txt",
+    "Ss2RsemSingleSample.rsem_gene_count": "gs://foo/call-RsemExpression/GSM1957573.gene.expected_counts",
+    "Ss2RsemSingleSample.aln_metrics": "gs://foo/call-CollectAlignmentSummaryMetrics/GSM1957573_alignment_metrics",
+    "Ss2RsemSingleSample.bam_file": "gs://foo/call-Star/Aligned.sortedByCoord.out.bam",
+    "Ss2RsemSingleSample.rsem_gene_results": "gs://foo/call-RsemExpression/GSM1957573.genes.results",
+    "Ss2RsemSingleSample.gene_unique_counts": "gs://foo/call-FeatureCountsUniqueMapping/GSM1957573.gene.counts.txt",
+    "Ss2RsemSingleSample.transcript_unique_counts": "gs://foo/call-FeatureCountsUniqueMapping/GSM1957573.transcripts.counts.txt",
+    "Ss2RsemSingleSample.rsem_isoform_results": "gs://foo/call-RsemExpression/GSM1957573.isoforms.results",
+    "Ss2RsemSingleSample.rna_metrics": "gs://foo/call-CollectRnaSeqMetrics/GSM1957573_rna_metrics",
+    "Ss2RsemSingleSample.bam_trans": "gs://foo/call-Star/Aligned.toTranscriptome.out.bam"
+  },
+  "workflowRoot": "gs://foo/",
+  "id": "0786e4c8-b25f-45b2-b19c-da883be4fa0b",
+  "inputs": {
+    "ref_fasta": "gs://foo/reference/Hg19_kco/Hg19.fa",
+    "rrna_interval": "gs://foo/reference/Hg19_kco/hg19.rRNA.interval_list",
+    "output_prefix": "GSM1957573",
+    "fastq_read1": "gs://org-humancellatlas-dss-dev/blobs/9b4c0dde8683f924975d0867903dc7a967f46bee5c0a025c451b9ba73e43f120.58f03f7c6c0887baa54da85db5c820cfbe25d367.89f6f8bec37ec1fc4560f3f99d47721d.e978e85d",
+    "gtf": "gs://foo/reference/Hg19_kco/Gencode_v19/Gencode_v19.GTF",
+    "star_genome": "gs://foo/reference/Hg19_kco/star_hg19_gencode_v19.tar.gz",
+    "fastq_read2": "gs://org-humancellatlas-dss-dev/blobs/c0d11199740a66150b8bb70a0474d8de9819e77f3f77b55dd04790e3fe6fb53c.bb5c8a68c155bad257cb7b93faef71a116cecba2.fb9bbafee8a92ced414b3658b1bb9517.942cd9d6",
+    "rsem_genome": "gs://foo/reference/Hg19_kco/rsem_hg19_gencode_v19.tar.gz",
+    "ref_flat": "gs://foo/reference/Hg19_kco/refFlat.txt"
+  },
+  "status": "Succeeded",
+  "parentWorkflowId": "60a0bbb9-b7d7-4f8a-9f7e-525834c87f2a",
+  "end": "2017-09-14T19:54:31.871Z",
+  "start": "2017-09-14T19:54:11.470Z"
+}

--- a/tests/data/outputs.txt
+++ b/tests/data/outputs.txt
@@ -1,0 +1,2 @@
+gs://foo/call-Star/Aligned.sortedByCoord.out.bam
+gs://foo/GSM1957573_rna_metrics

--- a/tests/data/response.json
+++ b/tests/data/response.json
@@ -1,0 +1,47 @@
+{
+  "_links" : {
+    "analyses" : {
+      "href" : "http://api.ingest.dev.data.humancellatlas.org/analyses{?page,size,sort}",
+      "templated" : true,
+      "title" : "Access or create analyses. Creation can only be done inside a submission envelope"
+    },
+    "projects" : {
+      "href" : "http://api.ingest.dev.data.humancellatlas.org/projects{?page,size,sort}",
+      "templated" : true,
+      "title" : "Access or create projects. Creation can only be done inside a submission envelope"
+    },
+    "protocols" : {
+      "href" : "http://api.ingest.dev.data.humancellatlas.org/protocols{?page,size,sort}",
+      "templated" : true,
+      "title" : "Access or create protocols"
+    },
+    "bundleManifests" : {
+      "href" : "http://api.ingest.dev.data.humancellatlas.org/bundleManifests{?page,size,sort}",
+      "templated" : true,
+      "title" : "Access or create bundle manifests (describing which submitted contents went into which bundle in the datastore)"
+    },
+    "samples" : {
+      "href" : "http://api.ingest.dev.data.humancellatlas.org/samples{?page,size,sort}",
+      "templated" : true,
+      "title" : "Access or create samples. Creation can only be done inside a submission envelope"
+    },
+    "assays" : {
+      "href" : "http://api.ingest.dev.data.humancellatlas.org/assays{?page,size,sort}",
+      "templated" : true,
+      "title" : "Access or create assays. Creation can only be done inside a submission envelope"
+    },
+    "files" : {
+      "href" : "http://api.ingest.dev.data.humancellatlas.org/files{?page,size,sort}",
+      "templated" : true,
+      "title" : "Access or create, within a submission envelope, a new assay"
+    },
+    "submissionEnvelopes" : {
+      "href" : "http://api.ingest.dev.data.humancellatlas.org/submissionEnvelopes{?page,size,sort}",
+      "templated" : true,
+      "title" : "Access or create new submission envelopes"
+    },
+    "profile" : {
+      "href" : "http://api.ingest.dev.data.humancellatlas.org/profile"
+    }
+  }
+}

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+tag=$1
+if [ -z "$tag" ]; then
+  echo "Must pass in tag to use for docker image, e.g. test.sh test123"
+  exit 1
+fi
+cd ..
+docker build --no-cache -t humancellatlas/pipeline-tools:$tag .
+cd -
+
+docker run humancellatlas/pipeline-tools:$tag bash -c "python -m unittest discover -v tests"

--- a/tests/test_create_analysis_json.py
+++ b/tests/test_create_analysis_json.py
@@ -1,0 +1,77 @@
+import unittest
+import os
+import json
+
+import pipeline_tools.create_analysis_json as analysis_json
+
+class TestCreateAnalysisJson(unittest.TestCase):
+
+    def test_create_inputs(self):
+        inputs_file = self.data_file('inputs.tsv') 
+        inputs = analysis_json.create_inputs(inputs_file)
+        self.assertEqual(inputs[0]['name'], 'fastq_read1')
+        self.assertEqual(inputs[0]['value'], 'gs://broad-dsde-mint-dev-teststorage/path/read1.fastq.gz')
+        self.assertEqual(inputs[0]['checksum'], 'd0f7d08f1980f7980f')
+        self.assertEqual(inputs[1]['name'], 'fastq_read2')
+        self.assertEqual(inputs[1]['value'], 'gs://broad-dsde-mint-dev-teststorage/path/read2.fastq.gz')
+        self.assertEqual(inputs[1]['checksum'], 'd0f7d08f1980f7980f')
+        self.assertEqual(inputs[2]['name'], 'output_prefix')
+        self.assertEqual(inputs[2]['value'], 'GSM1957573')
+        self.assertEqual(inputs[3]['name'], 'test_int')
+        self.assertEqual(inputs[3]['value'], '123')
+
+    def test_create_outputs(self):
+        outputs_file = self.data_file('outputs.txt') 
+        format_map_file = self.data_file('format_map.json') 
+        outputs = analysis_json.create_outputs(outputs_file, format_map_file)
+        output_lines = []
+        with open(outputs_file) as f:
+            for line in f:
+                output_lines.append(line.strip())
+        self.assertEqual(outputs[0]['file_path'], output_lines[0])
+        self.assertEqual(outputs[0]['format'], 'bam')
+        self.assertEqual(outputs[0]['name'], 'Aligned.sortedByCoord.out.bam')
+        self.assertEqual(outputs[1]['file_path'], output_lines[1])
+        self.assertEqual(outputs[1]['format'], 'metrics')
+        self.assertEqual(outputs[1]['name'], 'GSM1957573_rna_metrics')
+
+    def test_get_input_bundles(self):
+        bundles = analysis_json.get_input_bundles('foo,bar,baz')
+        self.assertEqual(bundles, ['foo', 'bar', 'baz'])
+
+    def test_get_start_end(self):
+        with open(self.data_file('metadata.json')) as f:
+            metadata = json.load(f)
+            start, end = analysis_json.get_start_end(metadata)
+            self.assertEqual(start, '2017-09-14T19:54:11.470Z')
+            self.assertEqual(end, '2017-09-14T19:54:31.871Z')
+
+    def test_get_tasks(self):
+        with open(self.data_file('metadata.json')) as f:
+            metadata = json.load(f)
+            tasks = analysis_json.get_tasks(metadata)
+            self.assertEqual(len(tasks), 5)
+            first_task = tasks[0]
+            self.assertEqual(first_task['name'], 'CollectAlignmentSummaryMetrics')
+            self.assertEqual(first_task['log_out'].split('/')[-1], 'CollectAlignmentSummaryMetrics-stdout.log')
+            self.assertEqual(first_task['log_err'].split('/')[-1], 'CollectAlignmentSummaryMetrics-stderr.log')
+            self.assertEqual(first_task['start_time'], '2017-09-14T19:54:22.691Z')
+            self.assertEqual(first_task['stop_time'], '2017-09-14T19:54:31.473Z')
+            self.assertEqual(first_task['memory'], '10 GB')
+            self.assertEqual(first_task['zone'], 'us-central1-b')
+            self.assertEqual(first_task['cpus'], 1)
+            self.assertEqual(first_task['disk_size'], 'local-disk 10 HDD')
+            self.assertEqual(first_task['docker_image'], 'humancellatlas/picard:2.10.10')
+
+    def test_get_format(self):
+        self.assertEqual(analysis_json.get_format('asdf', {}), 'unknown')
+        self.assertEqual(analysis_json.get_format('asdf.bam', {'.bam': 'bam'}), 'bam')
+        self.assertEqual(analysis_json.get_format('asdf.txt', {'.bam': 'bam'}), 'unknown')
+        self.assertEqual(analysis_json.get_format('asdf.bam', {'.bam': 'bam', '_metrics': 'metrics'}), 'bam')
+        self.assertEqual(analysis_json.get_format('asdf.foo_metrics', {'.bam': 'bam', '_metrics': 'metrics'}), 'metrics')
+
+    def data_file(self, file_name):
+        return os.path.split(__file__)[0] + '/data/'  + file_name
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_create_envelope.py
+++ b/tests/test_create_envelope.py
@@ -1,0 +1,57 @@
+import unittest
+import os
+import json
+
+import pipeline_tools.create_envelope as submit
+
+class TestCreateEnvelope(unittest.TestCase):
+
+    def test_get_entity(self):
+        with open(self.data_file('response.json')) as f:
+            js = json.load(f)
+            entity_url = submit.get_entity_url(js, 'analyses')
+            self.assertEqual(entity_url, 'http://api.ingest.dev.data.humancellatlas.org/analyses')
+
+    def test_get_input_bundle_uuid(self):
+        with open(self.data_file('analysis.json')) as f:
+            js = json.load(f)
+            self.assertEqual(submit.get_input_bundle_uuid(js), '75a7f618-9adc-48af-a249-0010305160f6')
+
+    def test_get_output_files(self):
+        with open(self.data_file('analysis.json')) as f:
+            js = json.load(f)
+            outputs = submit.get_output_files(js)
+            self.assertEqual(len(outputs), 3)
+            self.assertEqual(outputs[0]['fileName'], 'sample.bam')
+            self.assertEqual(outputs[0]['content']['name'], 'sample.bam')
+            self.assertEqual(outputs[0]['content']['format'], 'bam')
+
+    def test_check_status_bad_codes(self):
+        with self.assertRaises(ValueError):
+            submit.check_status(404, 'foo')
+        with self.assertRaises(ValueError):
+            submit.check_status(500, 'foo')
+        with self.assertRaises(ValueError):
+            submit.check_status(301, 'foo')
+
+    def test_check_status_acceptable_codes(self):
+        try:
+          submit.check_status(200, 'foo')
+        except ValueError as e:
+            self.fail(str(e))
+
+        try:
+            submit.check_status(202, 'foo')
+        except ValueError as e:
+            self.fail(str(e))
+
+        try:
+            submit.check_status(301, 'foo', '3xx')
+        except ValueError as e:
+            self.fail(str(e))
+
+    def data_file(self, file_name):
+        return os.path.split(__file__)[0] + '/data/'  + file_name
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_get_staging_urn.py
+++ b/tests/test_get_staging_urn.py
@@ -1,0 +1,45 @@
+import unittest
+import pipeline_tools.get_staging_urn as gsu
+
+class TestGetStagingUrn(unittest.TestCase):
+
+    def test_empty_js(self):
+        js = {}
+        self.assertIsNone(gsu.get_staging_urn(js))
+
+    def test_null_details(self):
+        js = { 
+            'stagingDetails': None
+        }
+        self.assertIsNone(gsu.get_staging_urn(js))
+
+    def test_null_location(self):
+        js = { 
+            'stagingDetails': {
+                'stagingAreaLocation': None
+            }
+        }
+        self.assertIsNone(gsu.get_staging_urn(js))
+
+    def test_null_value(self):
+        js = { 
+            'stagingDetails': {
+                'stagingAreaLocation': {
+                    'value': None
+                }
+            }
+        }
+        self.assertIsNone(gsu.get_staging_urn(js))
+
+    def test_valid_value(self):
+        js = { 
+            'stagingDetails': {
+                'stagingAreaLocation': {
+                    'value': 'test_urn'
+                }
+            }
+        }
+        self.assertEqual(gsu.get_staging_urn(js), 'test_urn')
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
As part of repo reorganization, I'd like to move this code here from https://github.com/HumanCellAtlas/skylab/tree/master/docker/secondary-analysis-python.

I haven't changed it, other than to rename secondary_analysis_python to pipeline_tools, which also required a small change to the Dockerfile.