### PR TITLE
Handle parsing subworkflows when creating analysis.json 

### DIFF
--- a/adapter_pipelines/submit.wdl
+++ b/adapter_pipelines/submit.wdl
@@ -21,7 +21,7 @@ task get_metadata {
     creds=/cromwell-metadata/cromwell_credentials.txt
     curl -u $(cut -f1 $creds):$(cut -f2 $creds) \
       --compressed \
-      "https://cromwell.mint-${runtime_environment}.broadinstitute.org/api/workflows/v1/$(cat workflow_id.txt)/metadata" > metadata.json
+      "https://cromwell.mint-${runtime_environment}.broadinstitute.org/api/workflows/v1/$(cat workflow_id.txt)/metadata?expandSubWorkflows=true" > metadata.json
   >>>
   runtime {
     docker: "gcr.io/broad-dsde-mint-${runtime_environment}/cromwell-metadata:0.1.1"

--- a/pipeline_tools/create_analysis_json.py
+++ b/pipeline_tools/create_analysis_json.py
@@ -91,28 +91,30 @@ def get_start_end(metadata):
 
 def get_tasks(metadata):
     calls = metadata['calls']
-
-    out_tasks = []
+    output_tasks = []
     for long_task_name in calls:
         task_name = long_task_name.split('.')[-1]
         task = calls[long_task_name][0]
-        runtime = task['runtimeAttributes']
+        if task.get('subWorkflowMetadata'):
+            output_tasks.extend(get_tasks(task['subWorkflowMetadata']))
+        else:
+            runtime = task['runtimeAttributes']
+            out_task = {
+                'name': task_name,
+                'cpus': int(runtime['cpu']),
+                'memory': runtime['memory'],
+                'disk_size': runtime['disks'],
+                'docker_image': runtime['docker'],
+                'zone': runtime['zones'],
+                'start_time': task['start'],
+                'stop_time': task['end'],
+                'log_out': task['stdout'],
+                'log_err': task['stderr']
+            }
+            output_tasks.append(out_task)
+    sorted_output_tasks = sorted(output_tasks, key=lambda k: k['name'])
+    return sorted_output_tasks
 
-        out_task = {
-            'name': task_name,
-            'cpus': int(runtime['cpu']),
-            'memory': runtime['memory'],
-            'disk_size': runtime['disks'],
-            'docker_image': runtime['docker'],
-            'zone': runtime['zones'],
-            'start_time': task['start'],
-            'stop_time': task['end'],
-            'log_out': task['stdout'],
-            'log_err': task['stderr']
-        }
-        out_tasks.append(out_task)
-    sorted_out_tasks = sorted(out_tasks, key=lambda k: k['name'])
-    return sorted_out_tasks
 
 def main():
     parser = argparse.ArgumentParser()


### PR DESCRIPTION
When parsing the metadata for workflow calls in `create_analysis_json.py` check if a call is a subworkflow and parse its calls recursively. This is needed in order to run the optimus and new smartseq2 adapter wdls, since those pipelines include subworkflows.

Note: The `humancellatlas/pipeline-tools:0.1.4` docker image will need to be updated to include these changes, so it would be easier to merge this into #5 if possible, since it makes changes to this script as well.