### PR TITLE
Fix setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ setup(name='pipeline-tools',
       author='Human Cell Atlas Data Coordination Platform Mint Team',
       author_email='mintteam@broadinstitute.org',
       license='BSD 3-clause "New" or "Revised" License',
-      packages=['pipeline_tools', 'tests'],
+      packages=['pipeline_tools'],
       install_requires=[
           'requests',
           'boto3',


### PR DESCRIPTION
PR #8 moved the tests dir to underneath pipeline_tools. We were specifying in setup.py to install a top level tests dir that no longer exists. This PR fixes that.