### PR TITLE
Turn on call-caching for all of the pipelines by default.

### DIFF
--- a/adapter_pipelines/10x/options.json
+++ b/adapter_pipelines/10x/options.json
@@ -1,3 +1,3 @@
 {
-  "read_from_cache": false
+  "read_from_cache": true
 }

--- a/adapter_pipelines/Optimus/options.json
+++ b/adapter_pipelines/Optimus/options.json
@@ -1,3 +1,3 @@
 {
-  "read_from_cache": false
+  "read_from_cache": true
 }

--- a/adapter_pipelines/smart_seq2/options.json
+++ b/adapter_pipelines/smart_seq2/options.json
@@ -1,3 +1,3 @@
 {
-  "read_from_cache": false
+  "read_from_cache": true
 }

--- a/adapter_pipelines/ss2_single_sample/options.json
+++ b/adapter_pipelines/ss2_single_sample/options.json
@@ -1,3 +1,3 @@
 {
-  "read_from_cache": false
+  "read_from_cache": true
 }


### PR DESCRIPTION
Turn on call-caching for all of the pipelines by default. This will speed up our integration test significantly.