### PR TITLE
Add stub submit wdl

### DIFF
--- a/adapter_pipelines/submit_stub/README.md
+++ b/adapter_pipelines/submit_stub/README.md
@@ -1,0 +1,8 @@
+# Stub submission WDL
+
+This version of the submit.wdl doesn't actually do anything.
+
+It has the same required inputs as the real submit wdl and we use it when we
+want to test adapter WDLs without submitting anything at the end. It can be
+helpful to exclude submission from certain tests because it can be time
+consuming and depends on availability of an external system.

--- a/adapter_pipelines/submit_stub/submit.wdl
+++ b/adapter_pipelines/submit_stub/submit.wdl
@@ -1,0 +1,27 @@
+task submit_stub {
+  command <<<
+    echo "This is a stub submission task for testing purposes only."
+  >>>
+  runtime {
+    docker: "python:2.7"
+  }
+}
+
+workflow submit {
+  Array[Object] inputs
+  Array[File] outputs
+  File format_map
+  String submit_url
+  String input_bundle_uuid
+  String reference_bundle
+  String run_type
+  String schema_version
+  String method
+  String runtime_environment
+  Int retry_seconds
+  Int timeout_seconds
+
+  call submit_stub
+
+  output {}
+}


### PR DESCRIPTION
See https://elastc.com/c/4btDIPv3/615-stub-submission-wdl

It needs the same name as the regular submit wdl so that it will work with existing adapter wdls without changes. (Existing adapter wdls import a file named submit.wdl.)