### PR TITLE
Update submit wdl to use cromwell-as-a-service

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 *.pyc
+docker/cromwell-metadata/cromwell_credentials.txt
+docker/cromwell-metadata/caas_key.json

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ WORKDIR /tools
 
 COPY . .
 
-RUN pip install .
+RUN pip install . --process-dependency-links
 
 # Install the latest hca-cli for submit.wdl
 RUN pip install hca==3.3.0

--- a/adapter_pipelines/Optimus/adapter.wdl
+++ b/adapter_pipelines/Optimus/adapter.wdl
@@ -23,7 +23,7 @@ task GetInputs {
     CODE
   >>>
   runtime {
-    docker: "quay.io/humancellatlas/secondary-analysis-pipeline-tools:v0.15.0"
+    docker: "quay.io/humancellatlas/secondary-analysis-pipeline-tools:v0.16.0"
   }
   output {
     String sample_id = read_string("inputs.tsv")
@@ -64,7 +64,7 @@ task inputs_for_submit {
     >>>
 
     runtime {
-      docker: "quay.io/humancellatlas/secondary-analysis-pipeline-tools:v0.15.0"
+      docker: "quay.io/humancellatlas/secondary-analysis-pipeline-tools:v0.16.0"
     }
 
     output {
@@ -103,7 +103,7 @@ task outputs_for_submit {
     >>>
 
     runtime {
-      docker: "quay.io/humancellatlas/secondary-analysis-pipeline-tools:v0.15.0"
+      docker: "quay.io/humancellatlas/secondary-analysis-pipeline-tools:v0.16.0"
     }
 
     output {
@@ -131,6 +131,7 @@ workflow AdapterOptimus {
   String run_type
   Int retry_seconds
   Int timeout_seconds
+  Boolean use_caas
 
   # Set runtime environment such as "dev" or "staging" or "prod" so submit task could choose proper docker image to use
   String runtime_environment
@@ -210,6 +211,7 @@ workflow AdapterOptimus {
       method = method,
       retry_seconds = retry_seconds,
       timeout_seconds = timeout_seconds,
-      runtime_environment = runtime_environment
+      runtime_environment = runtime_environment,
+      use_caas = use_caas
   }
 }

--- a/adapter_pipelines/ss2_single_sample/adapter.wdl
+++ b/adapter_pipelines/ss2_single_sample/adapter.wdl
@@ -23,7 +23,7 @@ task GetInputs {
     CODE
   >>>
   runtime {
-    docker: "quay.io/humancellatlas/secondary-analysis-pipeline-tools:v0.15.0"
+    docker: "quay.io/humancellatlas/secondary-analysis-pipeline-tools:v0.16.0"
   }
   output {
     Object inputs = read_object("inputs.tsv")
@@ -57,6 +57,7 @@ workflow AdapterSmartSeq2SingleCell{
   Int retry_seconds
   Int timeout_seconds
   String reference_bundle
+  Boolean use_caas
 
   # Set runtime environment such as "dev" or "staging" or "prod" so submit task could choose proper docker image to use
   String runtime_environment
@@ -190,6 +191,7 @@ workflow AdapterSmartSeq2SingleCell{
       method = method,
       retry_seconds = retry_seconds,
       timeout_seconds = timeout_seconds,
-      runtime_environment = runtime_environment
+      runtime_environment = runtime_environment,
+      use_caas = use_caas
   }
 }

--- a/adapter_pipelines/submit.wdl
+++ b/adapter_pipelines/submit.wdl
@@ -2,14 +2,16 @@
 task get_metadata {
   String analysis_output_path
   String runtime_environment
+  Boolean use_caas
 
   command <<<
     get-analysis-metadata \
       --analysis_output_path ${analysis_output_path} \
-      --runtime_environment ${runtime_environment}
+      --runtime_environment ${runtime_environment} \
+      --use_caas ${use_caas}
   >>>
   runtime {
-    docker: "gcr.io/broad-dsde-mint-${runtime_environment}/cromwell-metadata:0.1.4"
+    docker: "gcr.io/broad-dsde-mint-${runtime_environment}/cromwell-metadata:0.1.5"
   }
   output {
     File metadata = "metadata.json"
@@ -55,7 +57,7 @@ task create_submission {
   >>>
 
   runtime {
-    docker: "quay.io/humancellatlas/secondary-analysis-pipeline-tools:v0.15.0"
+    docker: "quay.io/humancellatlas/secondary-analysis-pipeline-tools:v0.16.0"
   }
   output {
     File analysis_json = "analysis.json"
@@ -103,7 +105,7 @@ task stage_and_confirm {
   >>>
 
   runtime {
-    docker: "quay.io/humancellatlas/secondary-analysis-pipeline-tools:v0.15.0"
+    docker: "quay.io/humancellatlas/secondary-analysis-pipeline-tools:v0.16.0"
   }
 }
 
@@ -120,11 +122,13 @@ workflow submit {
   String runtime_environment
   Int retry_seconds
   Int timeout_seconds
+  Boolean use_caas
 
   call get_metadata {
     input:
       analysis_output_path = outputs[0],
-      runtime_environment = runtime_environment
+      runtime_environment = runtime_environment,
+      use_caas=use_caas
   }
 
   call create_submission {

--- a/docker/cromwell-metadata/Dockerfile
+++ b/docker/cromwell-metadata/Dockerfile
@@ -1,0 +1,8 @@
+FROM quay.io/humancellatlas/secondary-analysis-pipeline-tools
+
+RUN mkdir /cromwell-metadata
+WORKDIR /cromwell-metadata
+
+COPY cromwell_credentials.txt .
+
+COPY caas_key.json .

--- a/docker/cromwell-metadata/README.md
+++ b/docker/cromwell-metadata/README.md
@@ -1,0 +1,10 @@
+This docker image is used in the `adapter_pipelines/submit.wdl` when retrieving metadata for the analysis pipeline from 
+Cromwell. Depending on the instance of Cromwell being used, the request to retrieve metadata may require a username and password, or
+a service account JSON key for Cromwell-as-a-Service (CAAS).
+
+Prior to building the docker image:
+
+1. Add the service account JSON key file for CAAS as `caas_key.json`. If you are not running the adapter 
+pipelines in CAAS, this file can remain empty.
+2. Add a `cromwell_credentials.txt` file that follows the format in `cromwell_credentials_template.txt`. If you are using 
+CAAS, this file can remain empty.

--- a/docker/cromwell-metadata/cromwell_credentials_template.txt
+++ b/docker/cromwell-metadata/cromwell_credentials_template.txt
@@ -1,0 +1,1 @@
+fake-user   fake-password   https://cromwell.test.broadinstitute.org

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,4 @@
 requests==2.18.4
 google-cloud-storage==1.8.0
+tenacity==4.10.0
+git+git://github.com/broadinstitute/cromwell-tools.git@v0.3.0

--- a/setup.py
+++ b/setup.py
@@ -9,12 +9,12 @@ setup(name='pipeline-tools',
       license='BSD 3-clause "New" or "Revised" License',
       packages=['pipeline_tools'],
       install_requires=[
-          'requests==2.18.4',
-          'boto3==1.6.6',
-          'mock==2.0.0',
-          'google-cloud-storage==1.8.0',
-          'requests-mock==1.4.0'
-
+          'requests>=2.18.4',
+          'mock>=2.0.0',
+          'google-cloud-storage>=1.8.0',
+          'requests-mock>=1.4.0',
+          'tenacity>=4.10.0',
+          'cromwell-tools'
       ],
       entry_points={
           "console_scripts": [
@@ -25,5 +25,8 @@ setup(name='pipeline-tools',
               'confirm-submission=pipeline_tools.confirm_submission:main'
           ]
       },
+      dependency_links=[
+            'git+git://github.com/broadinstitute/cromwell-tools.git@v0.3.0#egg=cromwell-tools-1.0.1'
+      ],
       include_package_data=True
       )


### PR DESCRIPTION
If using cromwell-as-a-service, get the bearer token from the service account json key and send a request to caas to get the workflow metadata.

Note: This is the same as https://github.com/HumanCellAtlas/pipeline-tools/pull/21, just under the same branch name as the corresponding Lira PR so that the integration test uses these branches together.

Please ensure the following when opening a PR:
- [x] Added or updated tests
- [x] Updated documentation
- [ ] Applied style guidelines
- [ ] Considered generalizability beyond our own use case
