### PR TITLE
Use offical blessed package to control the version(700)

### DIFF
--- a/pipeline_tools/__init__.py
+++ b/pipeline_tools/__init__.py
@@ -1,0 +1,10 @@
+"""The pkg_resources module will try to get the right version through the setuptools_scm, which will try to
+detect the version of pipeline_tools package from any git tags, commit hash codes. This works if this Python package
+ is either installed from PyPI or installed via git directly."""
+
+from pkg_resources import get_distribution, DistributionNotFound
+try:
+    __version__ = get_distribution(__name__).version
+except DistributionNotFound:
+    # package is not installed
+    pass

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,8 @@
 from setuptools import setup
 
 setup(name='pipeline-tools',
-      version='1.0.0.dev1',
+      use_scm_version=True,
+      setup_requires=['setuptools_scm'],
       description='Utilities for retrieving files from the HCA data storage service and submitting an analysis bundle to HCA-DCP',
       url='http://github.com/HumanCellAtlas/skylab',
       author='Human Cell Atlas Data Coordination Platform Mint Team',
@@ -14,7 +15,8 @@ setup(name='pipeline-tools',
           'google-cloud-storage>=1.8.0',
           'requests-mock>=1.4.0',
           'tenacity>=4.10.0',
-          'cromwell-tools'
+          'cromwell-tools',
+          'setuptools_scm==2.0.0'
       ],
       entry_points={
           "console_scripts": [


### PR DESCRIPTION
This PR follows the [instruction](https://pypi.org/project/setuptools_scm/) to manage the version of Pipeline-tools. This will be not only necessary for Lira's `/version` endpoint but also important to maintain the versions of all of our dependencies.

So in other applications, we can now get the version by:
```python
import pipeline_tools

pipeline_tools.__version__
```
And we don't need to update the `setup.py` manually anymore, it will automatically grab the right git tag.

Please ensure the following when opening a PR:
- [ ] Added or updated tests
- [ ] Updated documentation
- [ ] Applied style guidelines
- [x] Considered generalizability beyond our own use case
