### PR TITLE
Upgrade the version of hca cli and update the dockerfile.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,3 @@ WORKDIR /tools
 COPY . .
 
 RUN pip install . --process-dependency-links
-
-# Install the latest hca-cli for submit.wdl
-RUN pip install hca==3.3.0

--- a/setup.py
+++ b/setup.py
@@ -10,13 +10,14 @@ setup(name='pipeline-tools',
       license='BSD 3-clause "New" or "Revised" License',
       packages=['pipeline_tools'],
       install_requires=[
-          'requests>=2.18.4',
-          'mock>=2.0.0',
-          'google-cloud-storage>=1.8.0',
-          'requests-mock>=1.4.0',
-          'tenacity>=4.10.0',
           'cromwell-tools',
-          'setuptools_scm==2.0.0'
+          'google-cloud-storage>=1.8.0',
+          'hca>=3.5.0',
+          'mock>=2.0.0',
+          'requests>=2.18.4',
+          'requests-mock>=1.4.0',
+          'setuptools_scm==2.0.0',
+          'tenacity>=4.10.0',
       ],
       entry_points={
           "console_scripts": [


### PR DESCRIPTION
This PR fixes the submission problem in the dcp integration test by upgrading the version of the hca CLI.

Please ensure the following when opening a PR:
- [ ] Added or updated tests
- [ ] Updated documentation
- [ ] Applied style guidelines
- [ ] Considered generalizability beyond our own use case
