### PR TITLE
Retry on readtimeout 782

### DIFF
--- a/pipeline_tools/confirm_submission.py
+++ b/pipeline_tools/confirm_submission.py
@@ -1,8 +1,7 @@
 #!/usr/bin/env python
 
-import requests
 import argparse
-from tenacity import retry, retry_if_result, retry_if_exception_type, RetryError, before
+from tenacity import retry_if_result, RetryError
 from pipeline_tools.http_requests import HttpRequests
 
 

--- a/pipeline_tools/confirm_submission.py
+++ b/pipeline_tools/confirm_submission.py
@@ -1,8 +1,7 @@
 #!/usr/bin/env python
 
 import argparse
-import requests
-from tenacity import retry_if_result, RetryError, retry_if_exception_type
+from tenacity import retry_if_result, RetryError
 from pipeline_tools.http_requests import HttpRequests
 
 
@@ -36,7 +35,7 @@ def wait_for_valid_status(envelope_url, http_requests):
         .get(
             envelope_url,
             before=log_before(envelope_url),
-            retry=(retry_if_result(status_is_invalid) | retry_if_exception_type(requests.exceptions.ReadTimeout))
+            retry=retry_if_result(status_is_invalid)
         )
     )
     return True
@@ -60,9 +59,7 @@ def confirm(envelope_url, http_requests):
         'Content-type': 'application/json'
     }
     response = http_requests.put('{}/submissionEvent'.format(envelope_url),
-                                 headers=headers,
-                                 retry=retry_if_exception_type(requests.exceptions.ReadTimeout)
-                                 )
+                                 headers=headers)
     text = response.text
     print(text)
     return text

--- a/pipeline_tools/create_analysis_json.py
+++ b/pipeline_tools/create_analysis_json.py
@@ -21,7 +21,7 @@ def create_analysis(analysis_id, metadata_file, input_bundles_string, reference_
         format_map (str): path to file containing a map of file extensions to types
 
     Returns:
-        A dict representing the analysis json file to be submitted
+        analysis (dict): A dict representing the analysis json file to be submitted
     """
     print('Creating analysis.json for {}'.format(analysis_id))
 
@@ -66,7 +66,7 @@ def create_inputs(inputs_file):
         inputs_file (str): giving the path to the file containing inputs metadata
 
     Returns:
-        Array of dicts representing inputs metadata in the format required for the analysis json file
+        inputs (list): Array of dicts representing inputs metadata in the format required for the analysis json file.
     """
     inputs = []
     with open(inputs_file) as f:
@@ -97,7 +97,7 @@ def create_outputs(outputs_file, format_map, schema_version):
         schema_version (str): the version of the metadata schema that the analysis json should conform to
 
     Returns:
-        Array of dicts representing outputs metadata in the format required for the analysis json file
+        outputs (list): Array of dicts representing outputs metadata in the format required for the analysis json file.
     """
     with open(format_map) as f:
         extension_to_format = json.load(f)
@@ -132,7 +132,7 @@ def get_format(path, extension_to_format):
         extension_to_format (dict): dict mapping file extensions to file types
 
     Returns:
-        A string representing the format of the file
+        str: A string representing the format of the file
     """
     for ext in extension_to_format:
         if path.endswith(ext):
@@ -150,7 +150,8 @@ def get_tasks(metadata):
         metadata (dict): the workflow metadata
 
     Returns:
-        Array of dicts representing task metadata in the format required for the analysis json
+        sorted_output_tasks (list): Sorted array of dicts representing task metadata in the format required for
+            the analysis json.
     """
     calls = metadata['calls']
 
@@ -188,7 +189,7 @@ def create_process_core(analysis_id, schema_version):
         schema_version (str): the version of the metadata schema that the analysis json will conform to
 
     Returns:
-        Dict containing process_core metadata required for analysis json
+        dict: Dict containing process_core metadata required for analysis json
     """
     return {
         'process_id': analysis_id,
@@ -204,7 +205,7 @@ def create_process_type(schema_version):
         schema_version (str): the metadata schema version that the analysis json will conform to
 
     Returns:
-        Dict containing process_type metadata in the forma required for the analysis json
+        dict: Dict containing process_type metadata in the forma required for the analysis json
     """
     return {
         'text': 'analysis',

--- a/pipeline_tools/create_envelope.py
+++ b/pipeline_tools/create_envelope.py
@@ -4,8 +4,6 @@ import json
 import argparse
 from .dcp_utils import get_auth_token, make_auth_header
 from pipeline_tools.http_requests import HttpRequests
-import requests
-from tenacity import retry_if_exception_type
 
 
 def run(submit_url, analysis_json_path, schema_version):
@@ -71,8 +69,7 @@ def get_envelope_url(submit_url, auth_headers, http_requests):
     """
     print('Getting envelope url from {}'.format(submit_url))
     response = http_requests.get(submit_url,
-                                 headers=auth_headers,
-                                 retry=retry_if_exception_type(requests.exceptions.ReadTimeout))
+                                 headers=auth_headers)
     envelope_url = get_subject_url(response.json(), 'submissionEnvelopes')
     return envelope_url
 
@@ -94,8 +91,7 @@ def create_submission_envelope(envelope_url, auth_headers, http_requests):
     print('Creating submission envelope at {0}'.format(envelope_url))
     response = http_requests.post(envelope_url,
                                   '{}',
-                                  headers=auth_headers,
-                                  retry=retry_if_exception_type(requests.exceptions.ReadTimeout))
+                                  headers=auth_headers)
     envelope_js = response.json()
     return envelope_js
 
@@ -118,8 +114,7 @@ def create_analysis(analyses_url, auth_headers, analysis_json_contents, http_req
     print('Creating analysis at {0}'.format(analyses_url))
     response = http_requests.post(analyses_url,
                                   headers=auth_headers,
-                                  json=analysis_json_contents,
-                                  retry=retry_if_exception_type(requests.exceptions.ReadTimeout))
+                                  json=analysis_json_contents)
     analysis_js = response.json()
     return analysis_js
 
@@ -145,8 +140,7 @@ def add_input_bundles(input_bundles_url, auth_headers, analysis_json_contents, h
     print(bundle_refs_js)
     response = http_requests.put(input_bundles_url,
                                  headers=auth_headers,
-                                 json=bundle_refs_js,
-                                 retry=retry_if_exception_type(requests.exceptions.ReadTimeout))
+                                 json=bundle_refs_js)
     return response.json()
 
 
@@ -168,8 +162,7 @@ def add_file_reference(file_ref, file_refs_url, auth_headers, http_requests):
     print('Adding file: {}'.format(file_ref['fileName']))
     response = http_requests.put(file_refs_url,
                                  headers=auth_headers,
-                                 json=file_ref,
-                                 retry=retry_if_exception_type(requests.exceptions.ReadTimeout))
+                                 json=file_ref)
     return response.json()
 
 

--- a/pipeline_tools/create_envelope.py
+++ b/pipeline_tools/create_envelope.py
@@ -14,9 +14,6 @@ def run(submit_url, analysis_json_path, schema_version):
         analysis_json_path (str): path to analysis json file
         schema_version (str): version of metadata schema that submission should conform to
 
-    Returns:
-        Nothing returned
-
     Raises:
         requests.HTTPError: for 4xx errors or 5xx errors beyond timeout
     """
@@ -65,7 +62,7 @@ def get_envelope_url(submit_url, auth_headers, http_requests):
         http_requests (HttpRequests): the HttpRequests object to use
 
     Returns:
-        A string giving the url for creating envelopes
+        envelope_url (str): A string giving the url for creating envelopes
 
     Raises:
         requests.HTTPError: for 4xx errors or 5xx errors beyond timeout
@@ -85,7 +82,7 @@ def create_submission_envelope(envelope_url, auth_headers, http_requests):
         http_requests (HttpRequests): HttpRequests object to use
 
     Returns:
-        Dict representing the JSON response to the request
+        envelope_js (dict): Dict representing the JSON response to the request
 
     Raises:
         requests.HTTPError: for 4xx errors or 5xx errors beyond timeout
@@ -106,7 +103,7 @@ def create_analysis(analyses_url, auth_headers, analysis_json_contents, http_req
         http_requests (HttpRequests): HttpRequests object to use
 
     Returns:
-        dict representing the response JSON
+        analysis_js (dict): A dict represents the response JSON
 
     Raises:
         requests.HTTPError: for 4xx errors or 5xx errors beyond timeout
@@ -127,7 +124,7 @@ def add_input_bundles(input_bundles_url, auth_headers, analysis_json_contents, h
         http_requests (HttpRequests): the HttpRequests object to use
 
     Returns:
-        Dict representing the JSON response to the request
+        dict: Dict representing the JSON response to the request
 
     Raises:
         requests.HTTPError: for 4xx errors or 5xx errors beyond timeout
@@ -150,7 +147,7 @@ def add_file_reference(file_ref, file_refs_url, auth_headers, http_requests):
         http_requests (HttpRequests): the HttpRequests object to use
 
     Returns:
-        Dict representing the JSON response to the request
+        dict: Dict representing the JSON response to the request
 
     Raises:
         requests.HTTPError: for 4xx errors or 5xx errors beyond timeout
@@ -169,7 +166,7 @@ def get_subject_url(js, subject):
         'submissionEnvelope', 'add-file-reference')
 
     Returns:
-        A string giving the url for the given subject
+        subject_url (str): A string giving the url for the given subject
     """
     subject_url = js['_links'][subject]['href'].split('{')[0]
     print('Got url for {0}: {1}'.format(subject, subject_url))
@@ -183,7 +180,7 @@ def get_input_bundle_uuid(analysis_json):
         analysis_json (dict): metadata describing the analysis
 
     Returns:
-        A string representing the input bundle uuid
+        uuid (str): A string representing the input bundle uuid
     """
     bundle = analysis_json['input_bundles'][0]
     uuid = bundle
@@ -199,7 +196,7 @@ def get_output_files(analysis_json, schema_version):
         schema_version (str): the schema version that file references will conform to
 
     Returns:
-        A dict of metadata describing the output files produced by the analysis
+        output_refs (dict): A dict of metadata describing the output files produced by the analysis
     """
     outputs = analysis_json['outputs']
     output_refs = []

--- a/pipeline_tools/dcp_utils.py
+++ b/pipeline_tools/dcp_utils.py
@@ -1,4 +1,3 @@
-import requests
 import logging
 from pipeline_tools.http_requests import HttpRequests
 
@@ -13,7 +12,7 @@ def get_file_by_uuid(file_id, dss_url, http_requests):
         http_requests (HttpRequests): the HttpRequests object to use
 
     Returns:
-        dict representing the contents of the JSON file
+        dict: dict representing the contents of the JSON file
 
     Raises:
         requests.HTTPError: for 4xx errors or 5xx errors beyond timeout
@@ -38,7 +37,7 @@ def get_manifest(bundle_uuid, bundle_version, dss_url, http_requests):
         http_requests (HttpRequests): the HttpRequests object to use
 
     Returns:
-        A dict of the following form:
+        dict: A dict of the following form:
             {
                 'name_to_meta': dict mapping <str file name>: <dict file metadata>,
                 'url_to_name': dict mapping <str file url>: <str file name>
@@ -64,7 +63,7 @@ def get_manifest_file_dicts(manifest):
         manifest (dict): the bundle manifest
 
     Returns:
-        A dict of metadata describing files in the manifest, like:
+        dict: A dict of metadata describing files in the manifest, like:
             {
                 'name_to_meta': <dict>
                 'url_to_name': <dict>
@@ -103,7 +102,8 @@ def get_auth_token(http_requests,
 
     .. note::
 
-        We have hard-coded some test credentials here temporarily, which do not give any special permissions in the ingest service.
+        We have hard-coded some test credentials here temporarily, which do not give any special
+        permissions in the ingest service.
 
     Args:
         http_requests (HttpRequests): the HttpRequests object to use
@@ -114,7 +114,8 @@ def get_auth_token(http_requests,
         grant_type (str): type of OAuth 2.0 flow you want to run. e.g. client_credentials
 
     Returns:
-        A dict containing the JWT (JSON Web Token) and its expiry (24h by default), the scopes granted, and the token type.
+        auth_token (dict): A dict containing the JWT (JSON Web Token) and its expiry (24h by default),
+            the scopes granted, and the token type.
 
     Raises:
         requests.HTTPError: for 4xx errors or 5xx errors beyond timeout
@@ -139,11 +140,12 @@ def make_auth_header(auth_token):
     """Make the authorization headers to communicate with endpoints which implement Auth0 authentication API.
 
     Args:
-        auth_token (dict): a dict obtained from the Auth0 domain oauth endpoint, containing the signed JWT (JSON Web Token),
-        its expiry, the scopes granted, and the token type.
+        auth_token (dict): a dict obtained from the Auth0 domain oauth endpoint, containing the signed JWT
+            (JSON Web Token), its expiry, the scopes granted, and the token type.
 
     Returns:
-        A dict representing the headers with necessary token information to talk to Auth0 authentication required endpoints.
+        headers (dict): A dict representing the headers with necessary token information to talk to Auth0 authentication
+            required endpoints.
     """
     token_type = auth_token['token_type']
     access_token = auth_token['access_token']

--- a/pipeline_tools/gcs_utils.py
+++ b/pipeline_tools/gcs_utils.py
@@ -9,8 +9,11 @@ from io import BytesIO
 def get_filename_from_gs_link(link):
     """Get the filename corresponding to a google_storage link.
 
-    :param str link: A string of google cloud storage link.
-    :return str: A string of filename.
+    Args:
+        link (str): A string of google cloud storage link.
+
+    Returns:
+        str: A string of filename.
     """
     return link.split('/')[-1]
 
@@ -18,9 +21,11 @@ def get_filename_from_gs_link(link):
 def parse_bucket_blob_from_gs_link(path):
     """Utility to split a google storage path into bucket + blob name.
 
-    :param str path: A string of google cloud storage path (must have gs:// prefix)
-    :return str: A string of bucket name.
-    :return str: A string of blob name
+    Args:
+        path (str): A string of google cloud storage path (must have gs:// prefix)
+
+    Returns:
+        (str, str): A tuple of (bucket name, blob name)
     """
     if not path.startswith('gs://'):
         raise ValueError('%s path is not a valid link')
@@ -31,10 +36,13 @@ def parse_bucket_blob_from_gs_link(path):
 
 
 def download_to_buffer(blob):
-    """Return a bytes file-like object readable by requests and REST APIs
+    """Return a bytes file-like object readable by requests and REST APIs.
 
-    :param google.cloud.storage.Blob blob: google storage blob
-    :return _io.BufferedIOBase: readable file object
+    Args:
+        blob (google.cloud.storage.Blob): google storage blob
+
+    Returns:
+        _io.BufferedIOBase: readable file object
     """
     bytes_buffer = BytesIO()
     blob.download_to_file(bytes_buffer)
@@ -45,11 +53,14 @@ def download_to_buffer(blob):
 def download_gcs_blob(gcs_client, bucket_name, source_blob_name):
     """Use google.cloud.storage API to download a blob from the bucket.
 
-    :param GoogleCloudStorageClient gcs_client: A GoogleCloudStorageClient object with a
+    Args:
+        gcs_client (GoogleCloudStorageClient): A GoogleCloudStorageClient object with a
             google.cloud.storage.client.Client instance as a lazy-initialized property.
-    :param str bucket_name: A string of bucket name.
-    :param str source_blob_name: A string of source blob name that to be downloaded.
-    :return BufferedIOBase: File-like object returned by download_to_buffer.
+        bucket_name (str): A string of bucket name.
+        source_blob_name (str): A string of source blob name that to be downloaded.
+
+    Returns:
+        BufferedIOBase: File-like object returned by download_to_buffer.
     """
     logging.getLogger()
 
@@ -89,8 +100,9 @@ class GoogleCloudStorageClient(object):
     def __init__(self, key_location, scopes):
         """This class implements the client to interact with Google Cloud Storage.
 
-        :param str key_location: The location of Google Cloud Storage API key.
-        :param list scopes: A list of OAuth 2.0 scopes information.
+        Args:
+            key_location(str): The location of Google Cloud Storage API key.
+            scopes (list): A list of OAuth 2.0 scopes information.
         """
         self.key_location, self.scopes = key_location, scopes
 
@@ -98,7 +110,8 @@ class GoogleCloudStorageClient(object):
     def storage_client(self):
         """This lazy property returns an authenticated google cloud storage client.
 
-        :return google.cloud.storage.client.Client: An authenticated google cloud storage client.
+        Returns:
+            google.cloud.storage.client.Client: An authenticated google cloud storage client.
         """
         logging.getLogger()
         logging.debug('Configuring listener credentials using %s' % self.key_location)

--- a/pipeline_tools/get_analysis_metadata.py
+++ b/pipeline_tools/get_analysis_metadata.py
@@ -13,7 +13,7 @@ def get_workflow_id(analysis_output_path):
         analysis_output_path (str): path to workflow output file.
 
     Returns:
-        workflow_id: string giving Cromwell UUID of the workflow.
+        workflow_id (str): string giving Cromwell UUID of the workflow.
     """
     url = analysis_output_path
     hash_end = url.rfind("/call-")
@@ -31,7 +31,7 @@ def get_auth(credentials_file=None):
         credentials_file (str): Path to the file containing cromwell authentication credentials.
 
     Returns:
-        requests.auth.HTTPBasicAuth object to use for cromwell requests
+        requests.auth.HTTPBasicAuth: object to be used for cromwell requests
     """
     credentials_file = credentials_file or '/cromwell-metadata/cromwell_credentials.txt'
     with open(credentials_file) as f:
@@ -50,9 +50,6 @@ def get_metadata(runtime_environment, workflow_id, http_requests, use_caas=False
         workflow_id (str): the analysis workflow id.
         use_caas (bool): whether or not to use Cromwell-as-a-Service.
         caas_key_file (str): path to CaaS service account JSON key file.
-
-    Returns:
-        Nothing returned
 
     Raises:
         requests.HTTPError: for 4xx errors or 5xx errors beyond the timeout

--- a/pipeline_tools/get_staging_urn.py
+++ b/pipeline_tools/get_staging_urn.py
@@ -1,8 +1,7 @@
 #!/usr/bin/env python
 
 import argparse
-import requests
-from tenacity import retry_if_result, RetryError, retry_if_exception_type
+from tenacity import retry_if_result, RetryError
 from pipeline_tools.http_requests import HttpRequests
 
 
@@ -30,7 +29,7 @@ def run(envelope_url, http_requests):
         http_requests
         .get(
             envelope_url,
-            retry=(retry_if_result(urn_is_none) | retry_if_exception_type(requests.exceptions.ReadTimeout))
+            retry=retry_if_result(urn_is_none)
         )
     )
     urn = get_staging_urn(response.json())

--- a/pipeline_tools/get_staging_urn.py
+++ b/pipeline_tools/get_staging_urn.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python
 
 import argparse
-from tenacity import retry_if_result, RetryError
+import requests
+from tenacity import retry_if_result, RetryError, retry_if_exception_type
 from pipeline_tools.http_requests import HttpRequests
 
 
@@ -29,7 +30,7 @@ def run(envelope_url, http_requests):
         http_requests
         .get(
             envelope_url,
-            retry=retry_if_result(urn_is_none)
+            retry=(retry_if_result(urn_is_none) | retry_if_exception_type(requests.exceptions.ReadTimeout))
         )
     )
     urn = get_staging_urn(response.json())

--- a/pipeline_tools/get_staging_urn.py
+++ b/pipeline_tools/get_staging_urn.py
@@ -1,10 +1,8 @@
 #!/usr/bin/env python
 
-import requests
 import argparse
-from tenacity import retry, retry_if_result, retry_if_exception_type, RetryError
+from tenacity import retry_if_result, RetryError
 from pipeline_tools.http_requests import HttpRequests
-
 
 
 def run(envelope_url, http_requests):
@@ -12,6 +10,7 @@ def run(envelope_url, http_requests):
     staging urn, or if there is an error with the request.
 
     Args:
+        http_requests (HttpRequests): an HttpRequests object.
         envelope_url (str): the submission envelope url
 
     Returns:

--- a/pipeline_tools/http_requests.py
+++ b/pipeline_tools/http_requests.py
@@ -14,6 +14,7 @@ RETRY_MULTIPLIER = 'RETRY_MULTIPLIER'
 RETRY_MAX_INTERVAL = 'RETRY_MAX_INTERVAL'
 INDIVIDUAL_REQUEST_TIMEOUT = 'INDIVIDUAL_REQUEST_TIMEOUT'
 
+
 class HttpRequests(object):
     """Wraps requests library and adds ability to record requests and responses.
 
@@ -66,7 +67,8 @@ class HttpRequests(object):
         self.retry_max_interval = self._get_param(RETRY_MAX_INTERVAL, '60', float)
         self.individual_request_timeout = self._get_param(INDIVIDUAL_REQUEST_TIMEOUT, '60', float)
 
-    def _get_param(self, name, default, convert_fn=lambda x: x):
+    @staticmethod
+    def _get_param(name, default, convert_fn=lambda x: x):
         param_str = os.environ.get(name, default)
 
         # handle case where environment var is set to empty string
@@ -84,7 +86,7 @@ class HttpRequests(object):
             All arguments that requests.get accepts are accepted here.
 
         Returns:
-            A requests.Response object representing the response to the request.
+            requests.Response: An object representing the response to the request.
 
         Raises:
             requests.HTTPError: if 5xx error occurs
@@ -105,7 +107,7 @@ class HttpRequests(object):
             for 'body' -- use 'json' instead.
 
         Returns:
-            A requests.Response object representing the response to the request.
+            requests.Response: An object representing the response to the request.
 
         Raises:
             requests.HTTPError: if 5xx error occurs
@@ -126,7 +128,7 @@ class HttpRequests(object):
             for 'body' -- use 'json' instead.
 
         Returns:
-            A requests.Response object representing the response to the request.
+            requests.Response: An object representing the response to the request.
 
         Raises:
             requests.HTTPError: if 5xx error occurs
@@ -179,7 +181,7 @@ class HttpRequests(object):
             here except for 'body' -- use 'json' instead.
 
         Returns:
-            A requests.Response object representing the response to the request.
+            requests.Response: An object representing the response to the request.
 
         Raises:
             requests.HTTPError: if 5xx error occurs
@@ -248,10 +250,10 @@ class HttpRequests(object):
         zero-padded integer like 005 and foo is an arbitrary prefix.
 
         Args:
-            files: list of strings representing files in a directory that look like foo_n.txt
+            files (list): list of strings representing files in a directory that look like foo_n.txt
 
         Returns:
-            A string representing the next suffix, one higher than the highest one present
+            str: A string representing the next suffix, one higher than the highest one present
             in the given list.
         """
         if len(files) == 0:
@@ -268,8 +270,8 @@ class HttpRequests(object):
         Raises a ValueError and prints response_text if status is not in the expected range. Otherwise,
         just returns silently.
         Args:
-            status (int): The actual HTTP status code.
-            response_text (str): Text to print along with status code when mismatch occurs
+            response.status (int): The actual HTTP status code.
+            response.text (str): Text to print along with status code when mismatch occurs
 
         Raises:
             requests.HTTPError: for 5xx errors and prints response_text if status is not in the expected range. Otherwise,

--- a/pipeline_tools/http_requests.py
+++ b/pipeline_tools/http_requests.py
@@ -142,7 +142,8 @@ class HttpRequests(object):
         def is_retryable(error):
             def is_retryable_status_code(error):
                 return isinstance(error, requests.HTTPError) and not (400 <= error.response.status_code <= 499)
-            return is_retryable_status_code(error) or isinstance(error, requests.ConnectionError)
+            return is_retryable_status_code(error) or isinstance(error,
+                                                                 (requests.ConnectionError, requests.ReadTimeout))
 
         if 'retry' in kwargs:
             retry = kwargs['retry'] | retry_if_exception(is_retryable)

--- a/pipeline_tools/tests/test_confirm_submission.py
+++ b/pipeline_tools/tests/test_confirm_submission.py
@@ -51,6 +51,19 @@ class TestConfirmSubmission(unittest.TestCase):
         self.assertEqual(mock_request.call_count, 3)
 
     @requests_mock.mock()
+    def test_wait_for_valid_status_retries_on_read_timeout_error(self, mock_request):
+        envelope_url = 'http://api.ingest.dev.data.humancellatlas.org/submissionEnvelopes/abcde'
+
+        def _request_callback(request, context):
+            context.status_code = 500
+            raise requests.ReadTimeout
+
+        mock_request.get(envelope_url, json=_request_callback)
+        with self.assertRaises(requests.ReadTimeout), HttpRequestsManager():
+            confirm_submission.wait_for_valid_status(envelope_url, HttpRequests())
+        self.assertEqual(mock_request.call_count, 3)
+
+    @requests_mock.mock()
     def test_confirm_success(self, mock_request):
         envelope_url = 'http://api.ingest.dev.data.humancellatlas.org/submissionEnvelopes/abcde'
 
@@ -73,5 +86,18 @@ class TestConfirmSubmission(unittest.TestCase):
 
         mock_request.put('{}/submissionEvent'.format(envelope_url), json=_request_callback)
         with self.assertRaises(requests.HTTPError), HttpRequestsManager():
+            confirm_submission.confirm(envelope_url, HttpRequests())
+        self.assertEqual(mock_request.call_count, 3)
+
+    @requests_mock.mock()
+    def test_confirm_retries_on_read_timeout_error(self, mock_request):
+        envelope_url = 'http://api.ingest.dev.data.humancellatlas.org/submissionEnvelopes/abcde'
+
+        def _request_callback(request, context):
+            context.status_code = 500
+            raise requests.ReadTimeout
+
+        mock_request.put('{}/submissionEvent'.format(envelope_url), json=_request_callback)
+        with self.assertRaises(requests.ReadTimeout), HttpRequestsManager():
             confirm_submission.confirm(envelope_url, HttpRequests())
         self.assertEqual(mock_request.call_count, 3)

--- a/pipeline_tools/tests/test_create_envelope.py
+++ b/pipeline_tools/tests/test_create_envelope.py
@@ -52,6 +52,19 @@ class TestCreateEnvelope(unittest.TestCase):
         self.assertEqual(mock_request.call_count, 3)
 
     @requests_mock.mock()
+    def test_get_envelope_url_retries_on_read_timeout_error(self, mock_request):
+        submit_url = 'http://api.ingest.dev.data.humancellatlas.org/'
+
+        def _request_callback(request, context):
+            context.status_code = 500
+            raise requests.ReadTimeout
+
+        mock_request.get(submit_url, json=_request_callback)
+        with self.assertRaises(requests.ReadTimeout), HttpRequestsManager():
+            submit.get_envelope_url(submit_url, self.headers, HttpRequests())
+        self.assertEqual(mock_request.call_count, 3)
+
+    @requests_mock.mock()
     def test_create_submission_envelope(self, mock_request):
         pass
 
@@ -65,6 +78,19 @@ class TestCreateEnvelope(unittest.TestCase):
 
         mock_request.post(envelope_url, json=_request_callback)
         with self.assertRaises(requests.HTTPError), HttpRequestsManager():
+            submit.create_submission_envelope(envelope_url, self.headers, HttpRequests())
+        self.assertEqual(mock_request.call_count, 3)
+
+    @requests_mock.mock()
+    def test_create_submission_envelope_retries_onread_timeout_error(self, mock_request):
+        envelope_url = 'http://api.ingest.dev.data.humancellatlas.org/submissionEnvelopes'
+
+        def _request_callback(request, context):
+            context.status_code = 500
+            raise requests.ReadTimeout
+
+        mock_request.post(envelope_url, json=_request_callback)
+        with self.assertRaises(requests.ReadTimeout), HttpRequestsManager():
             submit.create_submission_envelope(envelope_url, self.headers, HttpRequests())
         self.assertEqual(mock_request.call_count, 3)
 
@@ -84,6 +110,19 @@ class TestCreateEnvelope(unittest.TestCase):
             submit.create_analysis(analyses_url, self.headers, self.analysis_json, HttpRequests())
         self.assertEqual(mock_request.call_count, 3)
 
+    @requests_mock.mock()
+    def test_create_analysis_retries_on_read_timeout_error(self, mock_request):
+        analyses_url = 'http://api.ingest.dev.data.humancellatlas.org/abcde/processes'
+
+        def _request_callback(request, context):
+            context.status_code = 500
+            raise requests.ReadTimeout
+
+        mock_request.post(analyses_url, json=_request_callback)
+        with self.assertRaises(requests.ReadTimeout), HttpRequestsManager():
+            submit.create_analysis(analyses_url, self.headers, self.analysis_json, HttpRequests())
+        self.assertEqual(mock_request.call_count, 3)
+
     def test_add_input_bundles(self):
         pass
 
@@ -97,6 +136,19 @@ class TestCreateEnvelope(unittest.TestCase):
 
         mock_request.put(input_bundles_url, json=_request_callback)
         with self.assertRaises(requests.HTTPError), HttpRequestsManager():
+            submit.add_input_bundles(input_bundles_url, self.headers, self.analysis_json, HttpRequests())
+        self.assertEqual(mock_request.call_count, 3)
+
+    @requests_mock.mock()
+    def test_add_input_bundles_retries_on_read_timeout_error(self, mock_request):
+        input_bundles_url = 'http://api.ingest.dev.data.humancellatlas.org/processes/abcde/bundleReferences'
+
+        def _request_callback(request, context):
+            context.status_code = 500
+            raise requests.ReadTimeout
+
+        mock_request.put(input_bundles_url, json=_request_callback)
+        with self.assertRaises(requests.ReadTimeout), HttpRequestsManager():
             submit.add_input_bundles(input_bundles_url, self.headers, self.analysis_json, HttpRequests())
         self.assertEqual(mock_request.call_count, 3)
 
@@ -125,6 +177,31 @@ class TestCreateEnvelope(unittest.TestCase):
             }
         }
         with self.assertRaises(requests.HTTPError), HttpRequestsManager():
+            submit.add_file_reference(file_ref, file_refs_url, self.headers, HttpRequests())
+        self.assertEqual(mock_request.call_count, 3)
+
+    @requests_mock.mock()
+    def test_add_file_reference_retries_on_read_timeout_error(self, mock_request):
+        file_refs_url = 'http://api.ingest.dev.data.humancellatlas.org/processes/abcde/fileReference'
+
+        def _request_callback(request, context):
+            context.status_code = 500
+            raise requests.ReadTimeout
+
+        mock_request.put(file_refs_url, json=_request_callback)
+        file_ref = {
+            'fileName': 'aligned_bam',
+            'content': {
+                'describedBy': 'https://schema.humancellatlas.org/type/file/schema_version/analysis_file',
+                'schema_type': 'file',
+                'file_core': {
+                    'describedBy': 'https://schema.humancellatlas.org/core/file/schema_version/file_core',
+                    'file_name': 'test',
+                    'file_format': 'bam'
+                }
+            }
+        }
+        with self.assertRaises(requests.ReadTimeout), HttpRequestsManager():
             submit.add_file_reference(file_ref, file_refs_url, self.headers, HttpRequests())
         self.assertEqual(mock_request.call_count, 3)
 

--- a/pipeline_tools/tests/test_get_staging_urn.py
+++ b/pipeline_tools/tests/test_get_staging_urn.py
@@ -80,6 +80,16 @@ class TestGetStagingUrn(unittest.TestCase):
             gsu.run(self.envelope_url, HttpRequests())
         self.assertEqual(mock_request.call_count, 3)
 
+    @requests_mock.mock()
+    def test_run_retry_if_read_timeout_error_occurs(self, mock_request):
+        def _request_callback(request, context):
+            context.status_code = 500
+            raise requests.ReadTimeout
+        mock_request.get(self.envelope_url, json=_request_callback)
+        with self.assertRaises(requests.ReadTimeout), HttpRequestsManager():
+            gsu.run(self.envelope_url, HttpRequests())
+        self.assertEqual(mock_request.call_count, 3)
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Add retry logic for ReadTimeout exception to submission step, so that workflows will retry if Ingest is temporarily unavailable: https://elastc.com/c/ZH5icvdf/782-retry-on-readtimeout-exceptions. I'm not sure if I have added the retry logic in the proper way tho.

Besides, there are also some style fixes in the PR.

Please ensure the following when opening a PR:
- [x] Added or updated tests
- [x] Updated documentation
- [x] Applied style guidelines
- [ ] Considered generalizability beyond our own use case
