### PR TITLE
[WIP] Update analysis JSON to v6 metadata schema

### DIFF
--- a/pipeline_tools/create_analysis_json.py
+++ b/pipeline_tools/create_analysis_json.py
@@ -34,7 +34,7 @@ def create_analysis(analysis_id, metadata_file, input_bundles_string, reference_
 
     input_bundles = input_bundles_string.split(',')
 
-    schema_url = 'https://schema.humancellatlas.org/type/process/analysis/{}/analysis_process'.format(schema_version)
+    schema_url = 'https://schema.humancellatlas.org/type/protocol/analysis/{}/analysis_protocol'.format(schema_version)
 
     analysis = {
         'analysis_run_type': run_type,
@@ -46,9 +46,9 @@ def create_analysis(analysis_id, metadata_file, input_bundles_string, reference_
         'tasks': tasks,
         'inputs': inputs,
         'outputs': outputs,
-        'process_core': create_process_core(analysis_id, schema_version),
-        'process_type': create_process_type(schema_version),
-        'schema_type': 'process',
+        'protocol_core': create_protocol_core(analysis_id, schema_version),
+        'protocol_type': create_protocol_type(schema_version),
+        'schema_type': 'protocol',
         'describedBy': schema_url
     }
 
@@ -181,7 +181,7 @@ def get_tasks(metadata):
     return sorted_output_tasks
 
 
-def create_process_core(analysis_id, schema_version):
+def create_protocol_core(analysis_id, schema_version):
     """Creates process_core entry for analysis json
 
     Args:
@@ -192,13 +192,13 @@ def create_process_core(analysis_id, schema_version):
         dict: Dict containing process_core metadata required for analysis json
     """
     return {
-        'process_id': analysis_id,
-        'describedBy': 'https://schema.humancellatlas.org/core/process/{}/process_core'.format(schema_version),
+        'protocol_id': analysis_id,
+        'describedBy': 'https://schema.humancellatlas.org/core/protocol/{}/protocol_core'.format(schema_version),
         'schema_version': schema_version
     }
 
 
-def create_process_type(schema_version):
+def create_protocol_type(schema_version):
     """Creates process_type metadata for analysis json
 
     Args:

--- a/pipeline_tools/create_envelope.py
+++ b/pipeline_tools/create_envelope.py
@@ -38,7 +38,7 @@ def run(submit_url, analysis_json_path, schema_version):
     # 3. Create analysis
     with open(analysis_json_path) as f:
         analysis_json_contents = json.load(f)
-    analyses_url = get_subject_url(envelope_js, 'processes')
+    analyses_url = get_subject_url(envelope_js, 'protocols')
     analysis_js = create_analysis(analyses_url, auth_headers, analysis_json_contents, http_requests)
 
     # 4. Add input bundles

--- a/pipeline_tools/tests/test_create_analysis_json.py
+++ b/pipeline_tools/tests/test_create_analysis_json.py
@@ -19,13 +19,13 @@ class TestCreateAnalysisJson(unittest.TestCase):
             outputs_file=self.data_file('outputs.txt'),
             format_map=self.data_file('format_map.json')
         )
-        self.assertEqual(js.get('process_core').get('process_id'), '12345abcde')
+        self.assertEqual(js.get('protocol_core').get('protocol_id'), '12345abcde')
         self.verify_inputs(js.get('inputs'))
         schema_url = 'https://schema.humancellatlas.org/type/file/v1.2.3/analysis_file'
         self.verify_outputs(js.get('outputs'), schema_url)
         self.verify_tasks(js.get('tasks'))
-        self.assertEqual(js.get('schema_type'), 'process')
-        schema_url = 'https://schema.humancellatlas.org/type/process/analysis/v1.2.3/analysis_process' 
+        self.assertEqual(js.get('schema_type'), 'protocol')
+        schema_url = 'https://schema.humancellatlas.org/type/protocol/analysis/v1.2.3/analysis_protocol'
         self.assertEqual(js.get('describedBy'), schema_url)
         self.assertEqual(js.get('computational_method'), 'foo_method')
         self.assertEqual(js.get('reference_bundle'), 'foo_ref_bundle')
@@ -60,27 +60,27 @@ class TestCreateAnalysisJson(unittest.TestCase):
         self.assertEqual(caj.get_format('asdf.bam', {'.bam': 'bam', '_metrics': 'metrics'}), 'bam')
         self.assertEqual(caj.get_format('asdf.foo_metrics', {'.bam': 'bam', '_metrics': 'metrics'}), 'metrics')
 
-    def test_create_process_core(self):
+    def test_create_protocol_core(self):
         analysis_id = '12345abcde'
         schema_version = 'good_version'
-        schema_url = 'https://schema.humancellatlas.org/core/process/{}/process_core'.format(schema_version)
+        schema_url = 'https://schema.humancellatlas.org/core/protocol/{}/protocol_core'.format(schema_version)
 
-        process_core = caj.create_process_core(analysis_id, schema_version)
+        protocol_core = caj.create_protocol_core(analysis_id, schema_version)
         expected_core = {
-            'process_id': analysis_id,
+            'protocol_id': analysis_id,
             'describedBy': schema_url,
             'schema_version': schema_version
         }
-        self.assertEqual(process_core, expected_core)
+        self.assertEqual(protocol_core, expected_core)
 
-    def test_create_process_type(self):
+    def test_create_protocol_type(self):
         schema_version = 'good_version'
-        process_type = caj.create_process_type(schema_version)
-        expected_process_type = {
+        protocol_type = caj.create_protocol_type(schema_version)
+        expected_protocol_type = {
             'text': 'analysis',
             'describedBy': 'https://schema.humancellatlas.org/module/ontology/{}/process_type_ontology'.format(schema_version)
         }
-        self.assertEqual(process_type, expected_process_type)
+        self.assertEqual(protocol_type, expected_protocol_type)
 
     def verify_inputs(self, inputs):
         self.assertEqual(inputs[0]['parameter_name'], 'fastq_read1')

--- a/pipeline_tools/tests/test_create_envelope.py
+++ b/pipeline_tools/tests/test_create_envelope.py
@@ -99,7 +99,7 @@ class TestCreateEnvelope(unittest.TestCase):
 
     @requests_mock.mock()
     def test_create_analysis_retries_on_error(self, mock_request):
-        analyses_url = 'http://api.ingest.dev.data.humancellatlas.org/abcde/processes'
+        analyses_url = 'http://api.ingest.dev.data.humancellatlas.org/abcde/protocols'
 
         def _request_callback(request, context):
             context.status_code = 500
@@ -112,7 +112,7 @@ class TestCreateEnvelope(unittest.TestCase):
 
     @requests_mock.mock()
     def test_create_analysis_retries_on_read_timeout_error(self, mock_request):
-        analyses_url = 'http://api.ingest.dev.data.humancellatlas.org/abcde/processes'
+        analyses_url = 'http://api.ingest.dev.data.humancellatlas.org/abcde/protocols'
 
         def _request_callback(request, context):
             context.status_code = 500
@@ -208,8 +208,8 @@ class TestCreateEnvelope(unittest.TestCase):
     def test_get_subject_url(self):
         with open(self.data_file('response.json')) as f:
             js = json.load(f)
-        entity_url = submit.get_subject_url(js, 'processes')
-        self.assertEqual(entity_url, 'http://api.ingest.dev.data.humancellatlas.org/processes')
+        entity_url = submit.get_subject_url(js, 'protocols')
+        self.assertEqual(entity_url, 'http://api.ingest.dev.data.humancellatlas.org/protocols')
 
     def test_get_input_bundle_uuid(self):
         with open(self.data_file('analysis.json')) as f:


### PR DESCRIPTION
The type of the analysis json file changed from "process" to "protocol" in the HCA v6 metadata schema, mainly affecting the schema urls.