### PR TITLE
Add Cromwell automated retries to submit wdl and ss2 adapter wdl

### DIFF
--- a/adapter_pipelines/ss2_single_sample/adapter.wdl
+++ b/adapter_pipelines/ss2_single_sample/adapter.wdl
@@ -76,6 +76,8 @@ workflow AdapterSmartSeq2SingleCell{
   # By default, don't record http requests, unless we override in inputs json
   Boolean record_http = false
 
+  Int max_cromwell_retries = 0
+
   call GetInputs as prep {
     input:
       bundle_uuid = bundle_uuid,
@@ -103,7 +105,8 @@ workflow AdapterSmartSeq2SingleCell{
       sample_name = prep.inputs.sample_id,
       output_name = prep.inputs.sample_id,
       fastq1 = prep.inputs.fastq_1,
-      fastq2 = prep.inputs.fastq_2
+      fastq2 = prep.inputs.fastq_2,
+      max_retries = max_cromwell_retries
   }
 
   call submit_wdl.submit {


### PR DESCRIPTION
Added Cromwell retries to adapter wdl and to the parts of submit wdl that are idempotent.

See: https://elastc.com/c/dkauyyIF/790-make-ss2-have-cromwell-retries
and related PRs
https://github.com/HumanCellAtlas/skylab/pull/114
https://github.com/HumanCellAtlas/lira/pull/82

- [ ] Added or updated tests
- [ ] Updated documentation
- [x] Applied style guidelines
- [x] Considered generalizability beyond our own use case
