### PR TITLE
Fix the order of stage and confirm tasks.

### DIFF
--- a/adapter_pipelines/submit.wdl
+++ b/adapter_pipelines/submit.wdl
@@ -150,11 +150,15 @@ task stage_files {
   output {
     Array[File] http_requests = glob("request_*.txt")
     Array[File] http_responses = glob("response_*.txt")
+    # Make this task output a placeholder string here for confirm_submission so that they can be executed in order
+    String ready_to_be_confirmed = "true"
   }
 }
 
 # Confirm the submission
 task confirm_submission {
+  # Make this task ask for a placeholder string here for so that stage_files task and this can be executed in order
+  String ready_to_be_confirmed
   String submission_url
   Int? retry_max_interval
   Float? retry_multiplier
@@ -253,6 +257,7 @@ workflow submit {
 
   call confirm_submission {
     input:
+      ready_to_be_confirmed = stage_files.ready_to_be_confirmed,
       submission_url = create_submission.submission_url,
       retry_timeout = retry_timeout,
       individual_request_timeout = individual_request_timeout,

--- a/adapter_pipelines/submit.wdl
+++ b/adapter_pipelines/submit.wdl
@@ -150,15 +150,15 @@ task stage_files {
   output {
     Array[File] http_requests = glob("request_*.txt")
     Array[File] http_responses = glob("response_*.txt")
-    # Make this task output a placeholder string here for confirm_submission so that they can be executed in order
-    String ready_to_be_confirmed = "true"
+    # Make this task output a placeholder Bool here for confirm_submission so that they can be executed in order
+    Boolean ready_to_be_confirmed = true
   }
 }
 
 # Confirm the submission
 task confirm_submission {
-  # Make this task ask for a placeholder string here for so that stage_files task and this can be executed in order
-  String ready_to_be_confirmed
+  # Make this task ask for a placeholder Bool here for so that stage_files task and this can be executed in order
+  Boolean ready_to_be_confirmed
   String submission_url
   Int? retry_max_interval
   Float? retry_multiplier


### PR DESCRIPTION
Previously I separated the confirm_submission from the stage_files task, but since they are not depending on each other, Cromwell will try to execute them at the same time, which causes some of the tests fail because of the long retry time. This PR fixes this problem by forcefully letting the 2 tasks depend on each other. 

Please ensure the following when opening a PR:
- [ ] Added or updated tests
- [ ] Updated documentation
- [ ] Applied style guidelines
- [ ] Considered generalizability beyond our own use case
