### PR TITLE
Update to v6 metadata schema

### DIFF
--- a/adapter_pipelines/10x/adapter.wdl
+++ b/adapter_pipelines/10x/adapter.wdl
@@ -64,7 +64,7 @@ task GetInputs {
     CODE
   >>>
   runtime {
-    docker: "quay.io/humancellatlas/secondary-analysis-pipeline-tools:v0.20.0"
+    docker: "quay.io/humancellatlas/secondary-analysis-pipeline-tools:v0.21.0"
   }
   output {
     Array[File] r1 = read_lines("r1.tsv")
@@ -99,7 +99,7 @@ task rename_files {
     CODE
   >>>
   runtime {
-    docker: "quay.io/humancellatlas/secondary-analysis-pipeline-tools:v0.20.0"
+    docker: "quay.io/humancellatlas/secondary-analysis-pipeline-tools:v0.21.0"
   }
   output {
     File r1_new = "${r1_name}"

--- a/adapter_pipelines/10x/adapter.wdl
+++ b/adapter_pipelines/10x/adapter.wdl
@@ -213,6 +213,7 @@ workflow Adapter10xCount {
   String reference_bundle
   String run_type
   String schema_version
+  String analysis_file_version
   String method
   Int retry_seconds
   Int timeout_seconds
@@ -324,6 +325,7 @@ workflow Adapter10xCount {
       reference_bundle = reference_bundle,
       run_type = run_type,
       schema_version = schema_version,
+      analysis_file_version = analysis_file_version,
       method = method,
       retry_seconds = retry_seconds,
       timeout_seconds = timeout_seconds,

--- a/adapter_pipelines/10x/adapter_example_static.json
+++ b/adapter_pipelines/10x/adapter_example_static.json
@@ -37,6 +37,7 @@
   "Adapter10xCount.dss_url": "https://dss.staging.data.humancellatlas.org/v1",
   "Adapter10xCount.method": "10xCount",
   "Adapter10xCount.schema_version": "4.6.1",
+  "Adapter10xCount.analysis_file_version": "5.2.1",
   "Adapter10xCount.run_type": "run",
   "Adapter10xCount.retry_seconds": 10,
   "Adapter10xCount.timeout_seconds": 600

--- a/adapter_pipelines/Optimus/adapter.wdl
+++ b/adapter_pipelines/Optimus/adapter.wdl
@@ -24,7 +24,7 @@ task GetInputs {
     CODE
   >>>
   runtime {
-    docker: "quay.io/humancellatlas/secondary-analysis-pipeline-tools:v0.20.0"
+    docker: "quay.io/humancellatlas/secondary-analysis-pipeline-tools:v0.21.0"
   }
   output {
     String sample_id = read_string("inputs.tsv")
@@ -66,7 +66,7 @@ task inputs_for_submit {
     >>>
 
     runtime {
-      docker: "quay.io/humancellatlas/secondary-analysis-pipeline-tools:v0.20.0"
+      docker: "quay.io/humancellatlas/secondary-analysis-pipeline-tools:v0.21.0"
     }
 
     output {
@@ -106,7 +106,7 @@ task outputs_for_submit {
     >>>
 
     runtime {
-      docker: "quay.io/humancellatlas/secondary-analysis-pipeline-tools:v0.20.0"
+      docker: "quay.io/humancellatlas/secondary-analysis-pipeline-tools:v0.21.0"
     }
 
     output {

--- a/adapter_pipelines/Optimus/adapter.wdl
+++ b/adapter_pipelines/Optimus/adapter.wdl
@@ -131,6 +131,7 @@ workflow AdapterOptimus {
   String reference_bundle
   String method
   String schema_version
+  String analysis_file_version
   String run_type
   Int retry_seconds
   Int timeout_seconds
@@ -211,6 +212,7 @@ workflow AdapterOptimus {
       reference_bundle = reference_bundle,
       run_type = run_type,
       schema_version = schema_version,
+      analysis_file_version = analysis_file_version,
       method = method,
       retry_seconds = retry_seconds,
       timeout_seconds = timeout_seconds,

--- a/adapter_pipelines/Optimus/adapter_example_static.json
+++ b/adapter_pipelines/Optimus/adapter_example_static.json
@@ -7,6 +7,7 @@
   "AdapterOptimus.format_map": "gs://hca-dcp-mint-test-data/adapters/file_format_map.json",
   "AdapterOptimus.method": "Optimus",
   "AdapterOptimus.schema_version": "5.1.0",
+  "AdapterOptimus.analysis_file_version": "5.2.1",
   "AdapterOptimus.run_type": "run",
   "AdapterOptimus.retry_seconds": 10,
   "AdapterOptimus.timeout_seconds": 1200

--- a/adapter_pipelines/Optimus/adapter_example_static_demo.json
+++ b/adapter_pipelines/Optimus/adapter_example_static_demo.json
@@ -7,6 +7,7 @@
   "AdapterOptimus.format_map": "gs://hca-dcp-mint-test-data/adapters/file_format_map.json",
   "AdapterOptimus.method": "Optimus",
   "AdapterOptimus.schema_version": "5.1.0",
+  "AdapterOptimus.analysis_file_version": "5.2.1",
   "AdapterOptimus.run_type": "run",
   "AdapterOptimus.retry_seconds": 10,
   "AdapterOptimus.timeout_seconds": 1200

--- a/adapter_pipelines/ss2_single_sample/adapter.wdl
+++ b/adapter_pipelines/ss2_single_sample/adapter.wdl
@@ -31,7 +31,7 @@ task GetInputs {
     CODE
   >>>
   runtime {
-    docker: "quay.io/humancellatlas/secondary-analysis-pipeline-tools:v0.20.0"
+    docker: "quay.io/humancellatlas/secondary-analysis-pipeline-tools:se-test-v6-changes"
   }
   output {
     Array[File] http_requests = glob("request_*.txt")

--- a/adapter_pipelines/ss2_single_sample/adapter.wdl
+++ b/adapter_pipelines/ss2_single_sample/adapter.wdl
@@ -31,7 +31,7 @@ task GetInputs {
     CODE
   >>>
   runtime {
-    docker: "quay.io/humancellatlas/secondary-analysis-pipeline-tools:se-test-v6-changes"
+    docker: "quay.io/humancellatlas/secondary-analysis-pipeline-tools:v0.21.0"
   }
   output {
     Array[File] http_requests = glob("request_*.txt")

--- a/adapter_pipelines/ss2_single_sample/adapter.wdl
+++ b/adapter_pipelines/ss2_single_sample/adapter.wdl
@@ -63,6 +63,7 @@ workflow AdapterSmartSeq2SingleCell{
   String submit_url
   String method
   String schema_version
+  String analysis_file_version
   String run_type
   Int? retry_max_interval
   Float? retry_multiplier
@@ -208,6 +209,7 @@ workflow AdapterSmartSeq2SingleCell{
       reference_bundle = reference_bundle,
       run_type = run_type,
       schema_version = schema_version,
+      analysis_file_version = analysis_file_version,
       method = method,
       retry_multiplier = retry_multiplier,
       retry_max_interval = retry_max_interval,

--- a/adapter_pipelines/ss2_single_sample/adapter_example_bundle_specific.json
+++ b/adapter_pipelines/ss2_single_sample/adapter_example_bundle_specific.json
@@ -1,5 +1,5 @@
 {
   "AdapterSmartSeq2SingleCell.bundle_uuid": "8eef9ab4-ac37-4ad8-a0f6-4cb72fe2ed98",
   "AdapterSmartSeq2SingleCell.bundle_version": "2018-01-05T184143.479268Z",
-  "AdapterSmartSeq2SingleCell.schema_version": "4.6.1"
+  "AdapterSmartSeq2SingleCell.schema_version": "7.0.0"
 }

--- a/adapter_pipelines/ss2_single_sample/adapter_example_static.json
+++ b/adapter_pipelines/ss2_single_sample/adapter_example_static.json
@@ -13,6 +13,6 @@
   "AdapterSmartSeq2SingleCell.reference_bundle": "bf51d668-3e14-4843-9bc7-5d676fdf0e01",
   "AdapterSmartSeq2SingleCell.format_map": "gs://hca-dcp-mint-test-data/adapters/file_format_map.json",
   "AdapterSmartSeq2SingleCell.method": "SmartSeq2SingleCell",
-  "AdapterSmartSeq2SingleCell.schema_version": "6.1.1",
+  "AdapterSmartSeq2SingleCell.schema_version": "7.0.0",
   "AdapterSmartSeq2SingleCell.run_type": "run"
 }

--- a/adapter_pipelines/ss2_single_sample/adapter_example_static.json
+++ b/adapter_pipelines/ss2_single_sample/adapter_example_static.json
@@ -13,6 +13,6 @@
   "AdapterSmartSeq2SingleCell.reference_bundle": "bf51d668-3e14-4843-9bc7-5d676fdf0e01",
   "AdapterSmartSeq2SingleCell.format_map": "gs://hca-dcp-mint-test-data/adapters/file_format_map.json",
   "AdapterSmartSeq2SingleCell.method": "SmartSeq2SingleCell",
-  "AdapterSmartSeq2SingleCell.schema_version": "5.1.0",
+  "AdapterSmartSeq2SingleCell.schema_version": "6.1.1",
   "AdapterSmartSeq2SingleCell.run_type": "run"
 }

--- a/adapter_pipelines/ss2_single_sample/adapter_example_static.json
+++ b/adapter_pipelines/ss2_single_sample/adapter_example_static.json
@@ -14,5 +14,6 @@
   "AdapterSmartSeq2SingleCell.format_map": "gs://hca-dcp-mint-test-data/adapters/file_format_map.json",
   "AdapterSmartSeq2SingleCell.method": "SmartSeq2SingleCell",
   "AdapterSmartSeq2SingleCell.schema_version": "7.0.0",
+  "AdapterSmartSeq2SingleCell.analysis_file_version": "5.2.1",
   "AdapterSmartSeq2SingleCell.run_type": "run"
 }

--- a/adapter_pipelines/ss2_single_sample/adapter_example_static_demo.json
+++ b/adapter_pipelines/ss2_single_sample/adapter_example_static_demo.json
@@ -9,6 +9,7 @@
   "AdapterSmartSeq2SingleCell.format_map": "gs://hca-dcp-mint-test-data/adapters/file_format_map.json",
   "AdapterSmartSeq2SingleCell.method": "SmartSeq2SingleCell",
   "AdapterSmartSeq2SingleCell.schema_version": "7.0.0",
+  "AdapterSmartSeq2SingleCell.analysis_file_version": "5.2.1",
   "AdapterSmartSeq2SingleCell.run_type": "run",
   "AdapterSmartSeq2SingleCell.retry_seconds": 10,
   "AdapterSmartSeq2SingleCell.timeout_seconds": 1200

--- a/adapter_pipelines/ss2_single_sample/adapter_example_static_demo.json
+++ b/adapter_pipelines/ss2_single_sample/adapter_example_static_demo.json
@@ -8,7 +8,7 @@
   "AdapterSmartSeq2SingleCell.reference_bundle": "bf51d668-3e14-4843-9bc7-5d676fdf0e01",
   "AdapterSmartSeq2SingleCell.format_map": "gs://hca-dcp-mint-test-data/adapters/file_format_map.json",
   "AdapterSmartSeq2SingleCell.method": "SmartSeq2SingleCell",
-  "AdapterSmartSeq2SingleCell.schema_version": "5.1.0",
+  "AdapterSmartSeq2SingleCell.schema_version": "7.0.0",
   "AdapterSmartSeq2SingleCell.run_type": "run",
   "AdapterSmartSeq2SingleCell.retry_seconds": 10,
   "AdapterSmartSeq2SingleCell.timeout_seconds": 1200

--- a/adapter_pipelines/submit.wdl
+++ b/adapter_pipelines/submit.wdl
@@ -93,7 +93,7 @@ task create_submission {
   >>>
 
   runtime {
-    docker: "quay.io/humancellatlas/secondary-analysis-pipeline-tools:se-test-v6-changes"
+    docker: "quay.io/humancellatlas/secondary-analysis-pipeline-tools:v0.21.0"
   }
   output {
     File analysis_json = "analysis.json"
@@ -147,7 +147,7 @@ task stage_files {
   >>>
 
   runtime {
-    docker: "quay.io/humancellatlas/secondary-analysis-pipeline-tools:se-test-v6-changes"
+    docker: "quay.io/humancellatlas/secondary-analysis-pipeline-tools:v0.21.0"
   }
   output {
     Array[File] http_requests = glob("request_*.txt")
@@ -186,7 +186,7 @@ task confirm_submission {
   >>>
 
   runtime {
-    docker: "quay.io/humancellatlas/secondary-analysis-pipeline-tools:se-test-v6-changes"
+    docker: "quay.io/humancellatlas/secondary-analysis-pipeline-tools:v0.21.0"
   }
 
   output {

--- a/adapter_pipelines/submit.wdl
+++ b/adapter_pipelines/submit.wdl
@@ -46,6 +46,7 @@ task create_submission {
   String run_type
   String method
   String schema_version
+  String analysis_file_version
   Array[Object] inputs
   Array[String] outputs
   File format_map
@@ -79,6 +80,7 @@ task create_submission {
       --run_type ${run_type} \
       --method ${method} \
       --schema_version ${schema_version} \
+      --analysis_file_version ${analysis_file_version} \
       --inputs_file ${write_objects(inputs)} \
       --outputs_file ${write_lines(outputs)} \
       --format_map ${format_map}
@@ -87,7 +89,7 @@ task create_submission {
     create-envelope \
       --submit_url ${submit_url} \
       --analysis_json_path analysis.json \
-      --schema_version ${schema_version}
+      --analysis_file_version ${analysis_file_version}
   >>>
 
   runtime {
@@ -211,6 +213,7 @@ workflow submit {
   Boolean use_caas
   # By default, don't record http requests
   Boolean record_http = false
+  String analysis_file_version = "5.2.1"
 
   call get_metadata {
     input:
@@ -229,6 +232,7 @@ workflow submit {
       reference_bundle = reference_bundle,
       run_type = run_type,
       schema_version = schema_version,
+      analysis_file_version = analysis_file_version,
       method = method,
       submit_url = submit_url,
       inputs = inputs,

--- a/adapter_pipelines/submit.wdl
+++ b/adapter_pipelines/submit.wdl
@@ -91,7 +91,7 @@ task create_submission {
   >>>
 
   runtime {
-    docker: "quay.io/humancellatlas/secondary-analysis-pipeline-tools:v0.20.0"
+    docker: "quay.io/humancellatlas/secondary-analysis-pipeline-tools:se-test-v6-changes"
   }
   output {
     File analysis_json = "analysis.json"
@@ -145,7 +145,7 @@ task stage_files {
   >>>
 
   runtime {
-    docker: "quay.io/humancellatlas/secondary-analysis-pipeline-tools:v0.20.0"
+    docker: "quay.io/humancellatlas/secondary-analysis-pipeline-tools:se-test-v6-changes"
   }
   output {
     Array[File] http_requests = glob("request_*.txt")
@@ -184,7 +184,7 @@ task confirm_submission {
   >>>
 
   runtime {
-    docker: "quay.io/humancellatlas/secondary-analysis-pipeline-tools:v0.20.0"
+    docker: "quay.io/humancellatlas/secondary-analysis-pipeline-tools:se-test-v6-changes"
   }
 
   output {

--- a/adapter_pipelines/submit.wdl
+++ b/adapter_pipelines/submit.wdl
@@ -204,6 +204,7 @@ workflow submit {
   String reference_bundle
   String run_type
   String schema_version
+  String analysis_file_version
   String method
   String runtime_environment
   Int? retry_max_interval
@@ -213,7 +214,6 @@ workflow submit {
   Boolean use_caas
   # By default, don't record http requests
   Boolean record_http = false
-  String analysis_file_version = "5.2.1"
 
   call get_metadata {
     input:

--- a/pipeline_tools/create_analysis_json.py
+++ b/pipeline_tools/create_analysis_json.py
@@ -34,7 +34,7 @@ def create_analysis(analysis_id, metadata_file, input_bundles_string, reference_
 
     input_bundles = input_bundles_string.split(',')
 
-    schema_url = 'https://schema.humancellatlas.org/type/process/analysis/{}/analysis_process'.format(schema_version)
+    schema_url = 'https://schema.humancellatlas.org/type/protocol/analysis/{}/analysis_protocol'.format(schema_version)
 
     analysis = {
         'analysis_run_type': run_type,
@@ -46,9 +46,9 @@ def create_analysis(analysis_id, metadata_file, input_bundles_string, reference_
         'tasks': tasks,
         'inputs': inputs,
         'outputs': outputs,
-        'process_core': create_process_core(analysis_id, schema_version),
-        'process_type': create_process_type(schema_version),
-        'schema_type': 'process',
+        'protocol_core': create_protocol_core(analysis_id, schema_version),
+        'protocol_type': create_protocol_type(schema_version),
+        'schema_type': 'protocol',
         'describedBy': schema_url
     }
 
@@ -181,7 +181,7 @@ def get_tasks(metadata):
     return sorted_output_tasks
 
 
-def create_process_core(analysis_id, schema_version):
+def create_protocol_core(analysis_id, schema_version):
     """Creates process_core entry for analysis json
 
     Args:
@@ -192,13 +192,13 @@ def create_process_core(analysis_id, schema_version):
         dict: Dict containing process_core metadata required for analysis json
     """
     return {
-        'process_id': analysis_id,
-        'describedBy': 'https://schema.humancellatlas.org/core/process/{}/process_core'.format(schema_version),
+        'protocol_id': analysis_id,
+        'describedBy': 'https://schema.humancellatlas.org/core/protocol/{}/protocol_core'.format(schema_version),
         'schema_version': schema_version
     }
 
 
-def create_process_type(schema_version):
+def create_protocol_type(schema_version):
     """Creates process_type metadata for analysis json
 
     Args:

--- a/pipeline_tools/create_envelope.py
+++ b/pipeline_tools/create_envelope.py
@@ -6,13 +6,13 @@ from .dcp_utils import get_auth_token, make_auth_header
 from pipeline_tools.http_requests import HttpRequests
 
 
-def run(submit_url, analysis_json_path, schema_version):
+def run(submit_url, analysis_json_path, analysis_file_version):
     """Create submission in ingest service.
 
     Args:
         submit_url (str): url of ingest service to use
         analysis_json_path (str): path to analysis json file
-        schema_version (str): version of metadata schema that submission should conform to
+        analysis_file_version (str): version of metadata schema that output files should conform to
 
     Raises:
         requests.HTTPError: for 4xx errors or 5xx errors beyond timeout
@@ -48,7 +48,7 @@ def run(submit_url, analysis_json_path, schema_version):
     # 5. Add file references
     file_refs_url = get_subject_url(analysis_js, 'add-file-reference')
     print('Adding file references at {0}'.format(file_refs_url))
-    output_files = get_output_files(analysis_json_contents, schema_version)
+    output_files = get_output_files(analysis_json_contents, analysis_file_version)
     for file_ref in output_files:
         add_file_reference(file_ref, file_refs_url, auth_headers, http_requests)
 
@@ -197,12 +197,12 @@ def get_input_bundle_uuid(analysis_json):
     return uuid
 
 
-def get_output_files(analysis_json, schema_version):
+def get_output_files(analysis_json, analysis_file_version):
     """Get the metadata describing the outputs of the analysis
 
     Args:
         analysis_json (dict): metadata describing the analysis
-        schema_version (str): the schema version that file references will conform to
+        analysis_file_version (str): the schema version that file references will conform to
 
     Returns:
         output_refs (dict): A dict of metadata describing the output files produced by the analysis
@@ -215,10 +215,9 @@ def get_output_files(analysis_json, schema_version):
         file_name = out['file_core']['file_name']
         output_ref['fileName'] = file_name
         output_ref['content'] = {
-            'describedBy': 'https://schema.humancellatlas.org/type/file/{}/analysis_file'.format(schema_version),
+            'describedBy': 'https://schema.humancellatlas.org/type/file/{}/analysis_file'.format(analysis_file_version),
             'schema_type': 'file',
             'file_core': {
-                'describedBy': 'https://schema.humancellatlas.org/core/file/{}/file_core'.format(schema_version),
                 'file_name': file_name,
                 'file_format': out['file_core']['file_format']
             }
@@ -231,9 +230,9 @@ def main():
     parser = argparse.ArgumentParser()
     parser.add_argument('--submit_url', required=True)
     parser.add_argument('--analysis_json_path', required=True)
-    parser.add_argument('--schema_version', required=True, help='The metadata schema version that the analysis.json conforms to')
+    parser.add_argument('--analysis_file_version', required=True, help='The metadata schema version that the analysis files conform to')
     args = parser.parse_args()
-    run(args.submit_url, args.analysis_json_path, args.schema_version)
+    run(args.submit_url, args.analysis_json_path, args.analysis_file_version)
 
 
 if __name__ == '__main__':

--- a/pipeline_tools/input_utils.py
+++ b/pipeline_tools/input_utils.py
@@ -19,13 +19,13 @@ def get_sample_id(metadata, schema_version, sequencing_protocol_id=None):
         return _get_sample_id_v4(metadata)
     elif schema_version.startswith('5.'):
         return _get_sample_id_v5(metadata)
-    elif schema_version.startswith('6.'):
-        return _get_sample_id_v6(metadata, sequencing_protocol_id)
+    elif int(schema_version[0]) >= 6:
+        return _get_sample_id_from_links(metadata, sequencing_protocol_id)
     else:
-        raise NotImplementedError('Only implemented for v4, v5 and v6 metadata')
+        raise NotImplementedError('Only implemented for v4 metadata and above.')
 
 
-def _get_sample_id_v6(links_json, sequencing_protocol_id):
+def _get_sample_id_from_links(links_json, sequencing_protocol_id):
     def is_sequencing_protocol_link(link, sequencing_protocol_id):
         return link['destination_id'] == sequencing_protocol_id and link['source_type'] == 'process'
 
@@ -147,16 +147,15 @@ def get_smart_seq_2_fastq_names(metadata, version):
         NotImplementedError: if metadata version is unsupported
     """
     version_prefix = int(version.split('.', 1)[0])
-    print(version_prefix)
-    if version_prefix >= 5:
-        return _get_smart_seq_2_fastq_names_v5_or_higher(metadata)
+    if version_prefix == 5 or version_prefix == 6:
+        return _get_smart_seq_2_fastq_names_v5_or_v6(metadata)
     elif version_prefix == 4:
         return _get_smart_seq_2_fastq_names_v4(metadata)
     else:
         raise NotImplementedError('Only implemented for v4 and v5 metadata')
 
 
-def _get_smart_seq_2_fastq_names_v5_or_higher(files_json):
+def _get_smart_seq_2_fastq_names_v5_or_v6(files_json):
     """Returns fastq file names
 
     Args:

--- a/pipeline_tools/input_utils.py
+++ b/pipeline_tools/input_utils.py
@@ -2,12 +2,12 @@ from pipeline_tools import dcp_utils
 from pipeline_tools.http_requests import HttpRequests
 
 
-def get_sample_id(metadata, version, sequencing_protocol_id=None):
+def get_sample_id(metadata, schema_version, sequencing_protocol_id=None):
     """Return the sample id from the given metadata
 
     Args:
         metadata (dict): metadata related to sample
-        version (str): version of the metadata
+        schema_version (str): version of the metadata
 
     Returns:
         String giving the sample id
@@ -15,11 +15,11 @@ def get_sample_id(metadata, version, sequencing_protocol_id=None):
     Raises:
         NotImplementedError: if version is unsupported
     """
-    if version.startswith('4.'):
+    if schema_version.startswith('4.'):
         return _get_sample_id_v4(metadata)
-    elif version.startswith('5.'):
+    elif schema_version.startswith('5.'):
         return _get_sample_id_v5(metadata)
-    elif version.startswith('6.'):
+    elif schema_version.startswith('6.'):
         return _get_sample_id_v6(metadata, sequencing_protocol_id)
     else:
         raise NotImplementedError('Only implemented for v4, v5 and v6 metadata')
@@ -87,17 +87,12 @@ def get_input_metadata_file_uuid(manifest_files, version):
     Raises:
         NotImplementedError: if version is unsupported
     """
-    # if version.startswith('5.'):
-    #     return _get_input_metadata_file_uuid_v5(manifest_files)
     if version.startswith('4.'):
         return _get_input_metadata_file_uuid_v4(manifest_files)
-    else:
-        return _get_input_metadata_file_uuid_v5(manifest_files)
-    # else:
-    #     raise NotImplementedError('Only implemented for v4 and v5 metadata')
+    return _get_input_metadata_file_uuid_v5_or_higher(manifest_files)
 
 
-def _get_input_metadata_file_uuid_v5(manifest_files):
+def _get_input_metadata_file_uuid_v5_or_higher(manifest_files):
     """Get the uuid of the files.json file"""
     return dcp_utils.get_file_uuid(manifest_files, 'file.json')
 
@@ -121,8 +116,6 @@ def get_sample_id_file_uuid(manifest_files, version):
     Raises:
         NotImplementedError: if metadata version is unsupported
     """
-    # if version.startswith('5.'):
-    #     return _get_sample_id_file_uuid_v5_or_higher(manifest_files)
     if version.startswith('4.'):
         return _get_sample_id_file_uuid_v4(manifest_files)
     else:
@@ -154,6 +147,7 @@ def get_smart_seq_2_fastq_names(metadata, version):
         NotImplementedError: if metadata version is unsupported
     """
     version_prefix = int(version.split('.', 1)[0])
+    print(version_prefix)
     if version_prefix >= 5:
         return _get_smart_seq_2_fastq_names_v5_or_higher(metadata)
     elif version_prefix == 4:
@@ -291,6 +285,7 @@ def get_metadata_to_process(manifest_files, dss_url, is_v5_or_higher, http_reque
     Raises:
         requests.HTTPError: for 4xx errors or 5xx errors beyond timeout
     """
+    sequencing_protocol_id = None
     if not is_v5_or_higher:
         schema_version = '4.x'
         inputs_metadata_file_uuid = dcp_utils.get_file_uuid(manifest_files, 'assay.json')
@@ -302,15 +297,22 @@ def get_metadata_to_process(manifest_files, dss_url, is_v5_or_higher, http_reque
         inputs_metadata_json = dcp_utils.get_file_by_uuid(inputs_metadata_file_uuid, dss_url, http_requests)
         schema_version = detect_schema_version(inputs_metadata_json)
         sample_id_file_json = dcp_utils.get_file_by_uuid(sample_id_file_uuid, dss_url, http_requests)
-    return inputs_metadata_json, sample_id_file_json, schema_version
+
+        if int(schema_version[0]) >= 6:
+            protocol_uuid = dcp_utils.get_file_uuid(manifest_files, 'protocol.json')
+            protocol_json = dcp_utils.get_file_by_uuid(protocol_uuid, dss_url, http_requests)
+            sequencing_protocol = [protocol for protocol in protocol_json['protocols'] if 'sequencing_protocol' in protocol['content']['describedBy']]
+            sequencing_protocol_id = sequencing_protocol[0]['hca_ingest']['document_id']
+
+    return inputs_metadata_json, sample_id_file_json, schema_version, sequencing_protocol_id
 
 
-def create_ss2_input_tsv(uuid, version, dss_url):
+def create_ss2_input_tsv(bundle_uuid, bundle_version, dss_url):
     """Create TSV of Smart-seq2 inputs
 
     Args:
-        uuid (str): the bundle uuid
-        version (str): the bundle version
+        bundle_uuid (str): the bundle uuid
+        bundle_version (str): the bundle version
         dss_url (str): the url for the DCP Data Storage Service
 
     Returns:
@@ -319,7 +321,7 @@ def create_ss2_input_tsv(uuid, version, dss_url):
     Raises:
         requests.HTTPError: for 4xx errors or 5xx errors beyond the timeout
     """
-    fastq_1_url, fastq_2_url, sample_id = _get_content_for_ss2_input_tsv(uuid, version, dss_url, HttpRequests())
+    fastq_1_url, fastq_2_url, sample_id = _get_content_for_ss2_input_tsv(bundle_uuid, bundle_version, dss_url, HttpRequests())
 
     print("Creating input map")
     with open("inputs.tsv", "w") as f:
@@ -328,12 +330,12 @@ def create_ss2_input_tsv(uuid, version, dss_url):
     print("Wrote input map")
 
 
-def _get_content_for_ss2_input_tsv(uuid, version, dss_url, http_requests):
+def _get_content_for_ss2_input_tsv(bundle_uuid, bundle_version, dss_url, http_requests):
     """Gather the necessary metadata for the ss2 input tsv
 
     Args:
-        uuid (str): the bundle uuid
-        version (str): the bundle version
+        bundle_uuid (str): the bundle uuid
+        bundle_version (str): the bundle version
         dss_url (str): the url for the DCP Data Storage Service
         http_requests (HttpRequests): the HttpRequests object to use
 
@@ -344,17 +346,12 @@ def _get_content_for_ss2_input_tsv(uuid, version, dss_url, http_requests):
         requests.HTTPError: on 4xx errors or 5xx errors beyond the timeout
     """
     # Get bundle manifest
-    print("Getting bundle manifest for id {0}, version {1}".format(uuid, version))
-    manifest = dcp_utils.get_manifest(uuid, version, dss_url, http_requests)
+    print("Getting bundle manifest for id {0}, version {1}".format(bundle_uuid, bundle_version))
+    manifest = dcp_utils.get_manifest(bundle_uuid, bundle_version, dss_url, http_requests)
     manifest_files = dcp_utils.get_manifest_file_dicts(manifest)
 
-    inputs_metadata_json, sample_id_file_json, schema_version = get_metadata_to_process(
+    inputs_metadata_json, sample_id_file_json, schema_version, sequencing_protocol_id = get_metadata_to_process(
         manifest_files, dss_url, is_v5_or_higher(manifest_files['name_to_meta']), http_requests)
-
-    protocol_uuid = dcp_utils.get_file_uuid(manifest_files, 'protocol.json')
-    protocol_json = dcp_utils.get_file_by_uuid(protocol_uuid, dss_url, http_requests)
-    sequencing_protocol = [protocol for protocol in protocol_json['protocols'] if 'sequencing_protocol' in protocol['content']['describedBy']]
-    sequencing_protocol_id = sequencing_protocol[0]['hca_ingest']['document_id']
 
     sample_id = get_sample_id(sample_id_file_json, schema_version, sequencing_protocol_id)
     fastq_1_name, fastq_2_name = get_smart_seq_2_fastq_names(inputs_metadata_json, schema_version)

--- a/pipeline_tools/tests/data/metadata/v6/ss2_links.json
+++ b/pipeline_tools/tests/data/metadata/v6/ss2_links.json
@@ -1,0 +1,73 @@
+{
+  "describedBy": "https://schema.humancellatlas.org/bundle/1.0.0/links",
+  "schema_type": "link_bundle",
+  "schema_version": "1.0.0",
+  "links": [
+    {
+      "source_type": "biomaterial",
+      "source_id": "4ee53206-80cd-4144-8c75-b62399a7ae99",
+      "destination_type": "process",
+      "destination_id": "4f8d5533-7d24-4443-9bf1-70c33ae545f9"
+    },
+    {
+      "source_type": "process",
+      "source_id": "4f8d5533-7d24-4443-9bf1-70c33ae545f9",
+      "destination_type": "protocol",
+      "destination_id": "faf667bd-08bf-4e9e-aa08-e2af4ed7a739"
+    },
+    {
+      "source_type": "process",
+      "source_id": "4f8d5533-7d24-4443-9bf1-70c33ae545f9",
+      "destination_type": "protocol",
+      "destination_id": "4f929153-0044-4003-8d14-a5da3ae13d26"
+    },
+    {
+      "source_type": "process",
+      "source_id": "4f8d5533-7d24-4443-9bf1-70c33ae545f9",
+      "destination_type": "file",
+      "destination_id": "7995d4e3-6589-4f29-b054-4e9f3ef5e0d5"
+    },
+    {
+      "source_type": "process",
+      "source_id": "4f8d5533-7d24-4443-9bf1-70c33ae545f9",
+      "destination_type": "file",
+      "destination_id": "d1ceb81e-0670-4c44-91be-96d7444c0867"
+    },
+    {
+      "source_type": "biomaterial",
+      "source_id": "4b10e428-e0f9-4278-858a-ad1be7da01df",
+      "destination_type": "process",
+      "destination_id": "b3f988e1-d28a-4735-8e2e-cc76081381c8"
+    },
+    {
+      "source_type": "process",
+      "source_id": "b3f988e1-d28a-4735-8e2e-cc76081381c8",
+      "destination_type": "protocol",
+      "destination_id": "99e7e610-964e-4766-b46b-1a3ef338131c"
+    },
+    {
+      "source_type": "process",
+      "source_id": "b3f988e1-d28a-4735-8e2e-cc76081381c8",
+      "destination_type": "protocol",
+      "destination_id": "bf29324b-57dd-4cf1-a754-6fb56a27aee3"
+    },
+    {
+      "source_type": "process",
+      "source_id": "b3f988e1-d28a-4735-8e2e-cc76081381c8",
+      "destination_type": "biomaterial",
+      "destination_id": "4ee53206-80cd-4144-8c75-b62399a7ae99"
+    },
+    {
+      "source_type": "biomaterial",
+      "source_id": "64d1d52d-fbc0-4c29-b198-623eb57ff0ce",
+      "destination_type": "process",
+      "destination_id": "8f82b7e1-69ef-4bc5-9f2a-fac751f23da2"
+    },
+    {
+      "source_type": "process",
+      "source_id": "8f82b7e1-69ef-4bc5-9f2a-fac751f23da2",
+      "destination_type": "biomaterial",
+      "destination_id": "4b10e428-e0f9-4278-858a-ad1be7da01df"
+    }
+  ]
+}

--- a/pipeline_tools/tests/test_create_analysis_json.py
+++ b/pipeline_tools/tests/test_create_analysis_json.py
@@ -14,18 +14,19 @@ class TestCreateAnalysisJson(unittest.TestCase):
             reference_bundle='foo_ref_bundle',
             run_type='foo_run_type',
             method='foo_method',
-            schema_version='v1.2.3',
+            schema_version='1.2.3',
+            analysis_file_version='4.5.6',
             inputs_file=self.data_file('inputs.tsv'),
             outputs_file=self.data_file('outputs.txt'),
             format_map=self.data_file('format_map.json')
         )
         self.assertEqual(js.get('protocol_core').get('protocol_id'), '12345abcde')
         self.verify_inputs(js.get('inputs'))
-        schema_url = 'https://schema.humancellatlas.org/type/file/v1.2.3/analysis_file'
-        self.verify_outputs(js.get('outputs'), schema_url)
+        file_schema_url = 'https://schema.humancellatlas.org/type/file/4.5.6/analysis_file'
+        self.verify_outputs(js.get('outputs'), file_schema_url)
         self.verify_tasks(js.get('tasks'))
         self.assertEqual(js.get('schema_type'), 'protocol')
-        schema_url = 'https://schema.humancellatlas.org/type/protocol/analysis/v1.2.3/analysis_protocol'
+        schema_url = 'https://schema.humancellatlas.org/type/protocol/analysis/1.2.3/analysis_protocol'
         self.assertEqual(js.get('describedBy'), schema_url)
         self.assertEqual(js.get('computational_method'), 'foo_method')
         self.assertEqual(js.get('reference_bundle'), 'foo_ref_bundle')
@@ -62,23 +63,18 @@ class TestCreateAnalysisJson(unittest.TestCase):
 
     def test_create_protocol_core(self):
         analysis_id = '12345abcde'
-        schema_version = 'good_version'
-        schema_url = 'https://schema.humancellatlas.org/core/protocol/{}/protocol_core'.format(schema_version)
 
-        protocol_core = caj.create_protocol_core(analysis_id, schema_version)
+        protocol_core = caj.create_protocol_core(analysis_id)
         expected_core = {
-            'protocol_id': analysis_id,
-            'describedBy': schema_url,
-            'schema_version': schema_version
+            'protocol_id': analysis_id
         }
         self.assertEqual(protocol_core, expected_core)
 
     def test_create_protocol_type(self):
         schema_version = 'good_version'
-        protocol_type = caj.create_protocol_type(schema_version)
+        protocol_type = caj.create_protocol_type()
         expected_protocol_type = {
             'text': 'analysis',
-            'describedBy': 'https://schema.humancellatlas.org/module/ontology/{}/process_type_ontology'.format(schema_version)
         }
         self.assertEqual(protocol_type, expected_protocol_type)
 

--- a/pipeline_tools/tests/test_create_analysis_json.py
+++ b/pipeline_tools/tests/test_create_analysis_json.py
@@ -19,13 +19,13 @@ class TestCreateAnalysisJson(unittest.TestCase):
             outputs_file=self.data_file('outputs.txt'),
             format_map=self.data_file('format_map.json')
         )
-        self.assertEqual(js.get('process_core').get('process_id'), '12345abcde')
+        self.assertEqual(js.get('protocol_core').get('protocol_id'), '12345abcde')
         self.verify_inputs(js.get('inputs'))
         schema_url = 'https://schema.humancellatlas.org/type/file/v1.2.3/analysis_file'
         self.verify_outputs(js.get('outputs'), schema_url)
         self.verify_tasks(js.get('tasks'))
-        self.assertEqual(js.get('schema_type'), 'process')
-        schema_url = 'https://schema.humancellatlas.org/type/process/analysis/v1.2.3/analysis_process' 
+        self.assertEqual(js.get('schema_type'), 'protocol')
+        schema_url = 'https://schema.humancellatlas.org/type/protocol/analysis/v1.2.3/analysis_protocol'
         self.assertEqual(js.get('describedBy'), schema_url)
         self.assertEqual(js.get('computational_method'), 'foo_method')
         self.assertEqual(js.get('reference_bundle'), 'foo_ref_bundle')
@@ -60,27 +60,27 @@ class TestCreateAnalysisJson(unittest.TestCase):
         self.assertEqual(caj.get_format('asdf.bam', {'.bam': 'bam', '_metrics': 'metrics'}), 'bam')
         self.assertEqual(caj.get_format('asdf.foo_metrics', {'.bam': 'bam', '_metrics': 'metrics'}), 'metrics')
 
-    def test_create_process_core(self):
+    def test_create_protocol_core(self):
         analysis_id = '12345abcde'
         schema_version = 'good_version'
-        schema_url = 'https://schema.humancellatlas.org/core/process/{}/process_core'.format(schema_version)
+        schema_url = 'https://schema.humancellatlas.org/core/protocol/{}/protocol_core'.format(schema_version)
 
-        process_core = caj.create_process_core(analysis_id, schema_version)
+        protocol_core = caj.create_protocol_core(analysis_id, schema_version)
         expected_core = {
-            'process_id': analysis_id,
+            'protocol_id': analysis_id,
             'describedBy': schema_url,
             'schema_version': schema_version
         }
-        self.assertEqual(process_core, expected_core)
+        self.assertEqual(protocol_core, expected_core)
 
-    def test_create_process_type(self):
+    def test_create_protocol_type(self):
         schema_version = 'good_version'
-        process_type = caj.create_process_type(schema_version)
-        expected_process_type = {
+        protocol_type = caj.create_protocol_type(schema_version)
+        expected_protocol_type = {
             'text': 'analysis',
             'describedBy': 'https://schema.humancellatlas.org/module/ontology/{}/process_type_ontology'.format(schema_version)
         }
-        self.assertEqual(process_type, expected_process_type)
+        self.assertEqual(protocol_type, expected_protocol_type)
 
     def verify_inputs(self, inputs):
         self.assertEqual(inputs[0]['parameter_name'], 'fastq_read1')

--- a/pipeline_tools/tests/test_create_envelope.py
+++ b/pipeline_tools/tests/test_create_envelope.py
@@ -99,7 +99,7 @@ class TestCreateEnvelope(unittest.TestCase):
 
     @requests_mock.mock()
     def test_create_analysis_retries_on_error(self, mock_request):
-        analyses_url = 'http://api.ingest.dev.data.humancellatlas.org/abcde/protocols'
+        analyses_url = 'http://api.ingest.dev.data.humancellatlas.org/abcde/processes'
 
         def _request_callback(request, context):
             context.status_code = 500
@@ -112,7 +112,7 @@ class TestCreateEnvelope(unittest.TestCase):
 
     @requests_mock.mock()
     def test_create_analysis_retries_on_read_timeout_error(self, mock_request):
-        analyses_url = 'http://api.ingest.dev.data.humancellatlas.org/abcde/protocols'
+        analyses_url = 'http://api.ingest.dev.data.humancellatlas.org/abcde/processes'
 
         def _request_callback(request, context):
             context.status_code = 500
@@ -206,8 +206,8 @@ class TestCreateEnvelope(unittest.TestCase):
     def test_get_subject_url(self):
         with open(self.data_file('response.json')) as f:
             js = json.load(f)
-        entity_url = submit.get_subject_url(js, 'protocols')
-        self.assertEqual(entity_url, 'http://api.ingest.dev.data.humancellatlas.org/protocols')
+        entity_url = submit.get_subject_url(js, 'processes')
+        self.assertEqual(entity_url, 'http://api.ingest.dev.data.humancellatlas.org/processes')
 
     def test_get_input_bundle_uuid(self):
         with open(self.data_file('analysis.json')) as f:

--- a/pipeline_tools/tests/test_create_envelope.py
+++ b/pipeline_tools/tests/test_create_envelope.py
@@ -170,7 +170,6 @@ class TestCreateEnvelope(unittest.TestCase):
                 'describedBy': 'https://schema.humancellatlas.org/type/file/schema_version/analysis_file',
                 'schema_type': 'file',
                 'file_core': {
-                    'describedBy': 'https://schema.humancellatlas.org/core/file/schema_version/file_core',
                     'file_name': 'test',
                     'file_format': 'bam'
                 }
@@ -195,7 +194,6 @@ class TestCreateEnvelope(unittest.TestCase):
                 'describedBy': 'https://schema.humancellatlas.org/type/file/schema_version/analysis_file',
                 'schema_type': 'file',
                 'file_core': {
-                    'describedBy': 'https://schema.humancellatlas.org/core/file/schema_version/file_core',
                     'file_name': 'test',
                     'file_format': 'bam'
                 }
@@ -228,8 +226,6 @@ class TestCreateEnvelope(unittest.TestCase):
         self.assertEqual(len(outputs), 3)
         self.assertEqual(outputs[0]['fileName'], 'aligned_bam')
         self.assertEqual(outputs[0]['content']['schema_type'], 'file')
-        self.assertEqual(outputs[0]['content']['describedBy'], analysis_file_schema_url)
-        self.assertEqual(outputs[0]['content']['file_core']['describedBy'], file_core_schema_url)
         self.assertEqual(outputs[0]['content']['file_core']['file_name'], 'aligned_bam')
         self.assertEqual(outputs[0]['content']['file_core']['file_format'], 'bam')
 

--- a/pipeline_tools/tests/test_create_envelope.py
+++ b/pipeline_tools/tests/test_create_envelope.py
@@ -99,7 +99,7 @@ class TestCreateEnvelope(unittest.TestCase):
 
     @requests_mock.mock()
     def test_create_analysis_retries_on_error(self, mock_request):
-        analyses_url = 'http://api.ingest.dev.data.humancellatlas.org/abcde/processes'
+        analyses_url = 'http://api.ingest.dev.data.humancellatlas.org/abcde/protocols'
 
         def _request_callback(request, context):
             context.status_code = 500
@@ -112,7 +112,7 @@ class TestCreateEnvelope(unittest.TestCase):
 
     @requests_mock.mock()
     def test_create_analysis_retries_on_read_timeout_error(self, mock_request):
-        analyses_url = 'http://api.ingest.dev.data.humancellatlas.org/abcde/processes'
+        analyses_url = 'http://api.ingest.dev.data.humancellatlas.org/abcde/protocols'
 
         def _request_callback(request, context):
             context.status_code = 500
@@ -208,8 +208,8 @@ class TestCreateEnvelope(unittest.TestCase):
     def test_get_subject_url(self):
         with open(self.data_file('response.json')) as f:
             js = json.load(f)
-        entity_url = submit.get_subject_url(js, 'processes')
-        self.assertEqual(entity_url, 'http://api.ingest.dev.data.humancellatlas.org/processes')
+        entity_url = submit.get_subject_url(js, 'protocols')
+        self.assertEqual(entity_url, 'http://api.ingest.dev.data.humancellatlas.org/protocols')
 
     def test_get_input_bundle_uuid(self):
         with open(self.data_file('analysis.json')) as f:

--- a/pipeline_tools/tests/test_input_utils.py
+++ b/pipeline_tools/tests/test_input_utils.py
@@ -171,7 +171,7 @@ class TestInputUtils(unittest.TestCase):
         mock_request.get(links_json_url, json=_links_json_callback)
         mock_request.get(file_json_url, json=_file_json_callback)
         with HttpRequestsManager():
-            inputs_json, sample_json, schema_version  = input_utils.get_metadata_to_process(
+            inputs_json, sample_json, schema_version, sequencing_protocol_id = input_utils.get_metadata_to_process(
                 manifest_files,
                 dss_url='https://fake_url',
                 is_v5_or_higher=True,
@@ -203,17 +203,18 @@ class TestInputUtils(unittest.TestCase):
             context.status_code = 200
             return manifest_json
 
+        version = 'bundle_version'
         links_json_url = 'https://fake_url/files/links_json_uuid?replica=gcp'
         mock_request.get(links_json_url, json=_links_json_callback)
         file_json_url = 'https://fake_url/files/file_json_uuid?replica=gcp'
         mock_request.get(file_json_url, json=_file_json_callback)
-        manifest_url = 'https://fake_url/bundles/foo_uuid?version=foo_version&replica=gcp&directurls=true'
+        manifest_url = 'https://fake_url/bundles/foo_uuid?version={}&replica=gcp&directurls=true'.format(version)
         mock_request.get(manifest_url, json=_manifest_callback)
 
         with HttpRequestsManager():
             fastq_1_url, fastq_2_url, sample_id  = input_utils._get_content_for_ss2_input_tsv(
-                uuid='foo_uuid',
-                version='foo_version',
+                bundle_uuid='foo_uuid',
+                bundle_version=version,
                 dss_url='https://fake_url',
                 http_requests=HttpRequests()
             )

--- a/pipeline_tools/tests/test_input_utils.py
+++ b/pipeline_tools/tests/test_input_utils.py
@@ -33,6 +33,8 @@ class TestInputUtils(unittest.TestCase):
             self.links_json_v5_extra_sample = json.load(f)
         with open(self.data_file('metadata/v5/ss2_links_no_sample.json')) as f:
             self.links_json_v5_no_sample = json.load(f)
+        with open(self.data_file('metadata/v6/ss2_links.json')) as f:
+            self.links_json_v6 = json.load(f)
 
     def test_get_sample_id_v4(self):
         sample_id = input_utils.get_sample_id(self.ss2_assay_json_v4, '4.x')
@@ -50,9 +52,14 @@ class TestInputUtils(unittest.TestCase):
         with self.assertRaises(ValueError):
             input_utils.get_sample_id(self.links_json_v5_no_sample, '5.2.1')
 
+    def test_get_sample_id_from_links(self):
+        sequencing_protocol_id = '4f929153-0044-4003-8d14-a5da3ae13d26'
+        sample_id = input_utils.get_sample_id(self.links_json_v6, '6.1.1', sequencing_protocol_id)
+        self.assertEqual(sample_id, '4ee53206-80cd-4144-8c75-b62399a7ae99')
+
     def test_get_sample_id_non_existent_version_raises_error(self):
         with self.assertRaises(NotImplementedError):
-            input_utils.get_sample_id(self.ss2_assay_json_v4, '-1')
+            input_utils.get_sample_id(self.ss2_assay_json_v4, '-1.')
 
     def test_get_input_metadata_file_uuid_v4(self):
         uuid = input_utils.get_input_metadata_file_uuid(self.ss2_manifest_files_v4, '4.x')
@@ -94,6 +101,14 @@ class TestInputUtils(unittest.TestCase):
         fastq_1_name, fastq_2_name = input_utils.get_smart_seq_2_fastq_names(self.ss2_files_json_v5, '5.2.1')
         self.assertEqual(fastq_1_name, 'R1.fastq.gz')
         self.assertEqual(fastq_2_name, 'R2.fastq.gz')
+
+    def test_get_version_prefix(self):
+        version_prefix = input_utils.get_version_prefix('5.0.0')
+        self.assertEqual(version_prefix, 5)
+
+    def test_get_version_prefix_invalid_format(self):
+        with self.assertRaises(ValueError):
+            input_utils.get_version_prefix('version')
 
     @pytest.mark.latest_schema
     def test_detect_schema_version(self):
@@ -139,7 +154,8 @@ class TestInputUtils(unittest.TestCase):
         self.assertEqual(r2, expected_r2)
         self.assertEqual(i1, expected_i1)
 
-    
+
+
     @requests_mock.mock()
     def test_get_metadata_to_process(self, mock_request):
         with open(self.data_file('metadata/v5/ss2_links.json')) as f:
@@ -226,6 +242,7 @@ class TestInputUtils(unittest.TestCase):
     @staticmethod
     def data_file(file_name):
         return os.path.split(__file__)[0] + '/data/' + file_name
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
- Update getting the sample id from `links_json`
- Renamed `uuid` and `version` to `bundle_uuid` and `bundle_version` for clarity in `input_utils.py`
- The type of the analysis JSON file changed from "process" to "protocol"
- Schemas are independently versioned, so we need to explicitly specify the schema versions we're using. Right now there are only two that are required when creating the analysis JSON (all unnecessary ones were removed):
    - analysis_protocol file: https://schema.humancellatlas.org/type/protocol/analysis/{schema_version}/analysis_protocol
    - output file: https://schema.humancellatlas.org/type/file/{analysis_file_version}/analysis_file


Please ensure the following when opening a PR:
- [x] Added or updated tests
- [ ] Updated documentation
- [ ] Applied style guidelines
- [ ] Considered generalizability beyond our own use case
