### PR TITLE
Fix parsing analysis workflow id

### DIFF
--- a/pipeline_tools/get_analysis_metadata.py
+++ b/pipeline_tools/get_analysis_metadata.py
@@ -16,9 +16,8 @@ def get_workflow_id(analysis_output_path):
         workflow_id (str): string giving Cromwell UUID of the workflow.
     """
     url = analysis_output_path
-    hash_end = url.rfind("/call-")
-    hash_start = url.rfind('/', 0, hash_end) + 1
-    workflow_id = url[hash_start:hash_end]
+    calls = url.split('/call-')
+    workflow_id = calls[1].split('/')[-1]
     with open('workflow_id.txt', 'w') as f:
         f.write(workflow_id)
     return workflow_id

--- a/pipeline_tools/tests/test_get_analysis_metadata.py
+++ b/pipeline_tools/tests/test_get_analysis_metadata.py
@@ -19,7 +19,6 @@ class TestGetAnalysisMetadata(unittest.TestCase):
         self.cromwell_url = '{}/{}/metadata?expandSubWorkflows=true'.format(base_url, self.workflow_id)
         self.caas_url = '{}/{}/metadata?expandSubWorkflows=true'.format(caas_base_url, self.workflow_id)
 
-    @unittest.skip('Skipping until get_worflow_id correctly parses the analysis subworkflow id')
     def test_get_workflow_id(self):
         analysis_output_path = 'gs://broad-dsde-mint-dev-cromwell-execution/cromwell-executions/AdapterSmartSeq2SingleCell/workflow_id/call-analysis/SmartSeq2SingleCell/analysis_subworkflow_id/call-qc/RunHisat2Pipeline/qc_workflow_id/call-Hisat2/12345_qc.hisat2.met.txt'
         result = get_analysis_metadata.get_workflow_id(analysis_output_path)


### PR DESCRIPTION
Get the first subworkflow id from the analysis output path, which corresponds to the analysis workflow id, instead of always getting the last workflow id in the path. 

Please ensure the following when opening a PR:
- [x] Added or updated tests
- [ ] Updated documentation
- [ ] Applied style guidelines
- [ ] Considered generalizability beyond our own use case
