### PR TITLE
By default, don't submit md5 checksums in metadata (287)

### DIFF
--- a/adapter_pipelines/Optimus/adapter.wdl
+++ b/adapter_pipelines/Optimus/adapter.wdl
@@ -124,8 +124,9 @@ workflow AdapterOptimus {
   String runtime_environment
   # By default, don't record http requests, unless we override in inputs json
   Boolean record_http = false
-
   Int max_cromwell_retries = 0
+  Boolean add_md5s = false
+
   String pipeline_tools_version = "v0.26.0"
 
   call GetInputs as prep {
@@ -215,6 +216,7 @@ workflow AdapterOptimus {
       runtime_environment = runtime_environment,
       use_caas = use_caas,
       record_http = record_http,
-      pipeline_tools_version = pipeline_tools_version
+      pipeline_tools_version = pipeline_tools_version,
+      add_md5s = add_md5s
   }
 }

--- a/adapter_pipelines/Optimus/adapter_example_static.json
+++ b/adapter_pipelines/Optimus/adapter_example_static.json
@@ -9,5 +9,6 @@
   "AdapterOptimus.analysis_file_version": "5.2.1",
   "AdapterOptimus.analysis_protocol_schema_version": "8.0.0",
   "AdapterOptimus.analysis_process_schema_version": "8.0.0",
-  "AdapterOptimus.run_type": "run"
+  "AdapterOptimus.run_type": "run",
+  "AdapterOptimus.add_md5s": false
 }

--- a/adapter_pipelines/ss2_single_sample/adapter.wdl
+++ b/adapter_pipelines/ss2_single_sample/adapter.wdl
@@ -80,8 +80,9 @@ workflow AdapterSmartSeq2SingleCell{
   String runtime_environment
   # By default, don't record http requests, unless we override in inputs json
   Boolean record_http = false
-
   Int max_cromwell_retries = 0
+  Boolean add_md5s = false
+
   String pipeline_tools_version = "v0.26.0"
 
   call GetInputs as prep {
@@ -227,6 +228,7 @@ workflow AdapterSmartSeq2SingleCell{
       runtime_environment = runtime_environment,
       use_caas = use_caas,
       record_http = record_http,
-      pipeline_tools_version = pipeline_tools_version
+      pipeline_tools_version = pipeline_tools_version,
+      add_md5s = add_md5s
   }
 }

--- a/adapter_pipelines/ss2_single_sample/adapter_example_static.json
+++ b/adapter_pipelines/ss2_single_sample/adapter_example_static.json
@@ -16,5 +16,6 @@
   "AdapterSmartSeq2SingleCell.analysis_file_version": "5.2.1",
   "AdapterSmartSeq2SingleCell.analysis_protocol_schema_version": "8.0.0",
   "AdapterSmartSeq2SingleCell.analysis_process_schema_version": "8.0.0",
-  "AdapterSmartSeq2SingleCell.run_type": "run"
+  "AdapterSmartSeq2SingleCell.run_type": "run",
+  "AdapterSmartSeq2SingleCell.add_md5s": false
 }

--- a/adapter_pipelines/submit.wdl
+++ b/adapter_pipelines/submit.wdl
@@ -62,6 +62,7 @@ task create_submission {
   Int? individual_request_timeout
   Boolean record_http
   String pipeline_tools_version
+  Boolean add_md5s
 
   command <<<
     export RECORD_HTTP_REQUESTS="${record_http}"
@@ -92,7 +93,8 @@ task create_submission {
       --analysis_file_version ${analysis_file_version} \
       --inputs_file ${write_objects(inputs)} \
       --outputs_file ${write_lines(outputs)} \
-      --format_map ${format_map}
+      --format_map ${format_map} \
+      --add_md5s ${add_md5s}
 
     # Now build the submission object
     create-envelope \
@@ -244,6 +246,7 @@ workflow submit {
   # By default, don't record http requests
   Boolean record_http = false
   String pipeline_tools_version
+  Boolean add_md5s
 
   call get_metadata {
     input:
@@ -280,7 +283,8 @@ workflow submit {
       retry_multiplier = retry_multiplier,
       retry_max_interval = retry_max_interval,
       record_http = record_http,
-      pipeline_tools_version = pipeline_tools_version
+      pipeline_tools_version = pipeline_tools_version,
+      add_md5s = add_md5s
   }
 
   call stage_files {

--- a/adapter_pipelines/submit_stub/submit.wdl
+++ b/adapter_pipelines/submit_stub/submit.wdl
@@ -31,6 +31,7 @@ workflow submit {
   # By default, don't record http requests
   Boolean record_http = false
   String pipeline_tools_version
+  Boolean add_md5s
 
   call submit_stub
 


### PR DESCRIPTION
Submitting md5s at scale is not working well, causing a lot of failures in the scale test, and long term there are other reasons why we might not want to continue doing it. For now, this PR turns md5s off by default but adds a parameter to turn them back on if we want to.

See HumanCellAtlas/secondary-analysis#287

- [x] Added or updated tests
- [x] Updated documentation
- [x] Applied style guidelines
- [x] Considered generalizability beyond our own use case
