### PR TITLE
Update to CaaS Prod

### DIFF
--- a/adapter_pipelines/submit.wdl
+++ b/adapter_pipelines/submit.wdl
@@ -28,7 +28,7 @@ task get_metadata {
       --use_caas ${use_caas}
   >>>
   runtime {
-    docker: "gcr.io/broad-dsde-mint-${runtime_environment}/cromwell-metadata:v0.25.0"
+    docker: "gcr.io/broad-dsde-mint-${runtime_environment}/cromwell-metadata:v1.0.0"
   }
   output {
     File metadata = "metadata.json"

--- a/docker/cromwell-metadata/Dockerfile
+++ b/docker/cromwell-metadata/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/humancellatlas/secondary-analysis-pipeline-tools:v0.25.0
+FROM quay.io/humancellatlas/secondary-analysis-pipeline-tools:v0.26.0
 
 RUN mkdir /cromwell-metadata
 WORKDIR /cromwell-metadata


### PR DESCRIPTION
Update to use `cromwell-metadata:v1.0.0` in submit WDL which will use CaaS prod.

**Note:** This PR must be merged along with https://github.com/HumanCellAtlas/secondary-analysis/pull/266 so that we won't break the Mintegration test suite!

**Note:** This PR requires `cromwell-metadata:v1.0.0`to be built and pushed to `gcr.io/broad-dsde-mint-{dev, test, staging}/cromwell-metadata:v1.0.0` manually.

Please ensure the following when opening a PR:
- [ ] Added or updated tests
- [ ] Updated documentation
- [ ] Applied style guidelines
- [ ] Considered generalizability beyond our own use case
