### PR TITLE
Add maxRetries to submit wdl tasks

### DIFF
--- a/adapter_pipelines/ss2_single_sample/adapter.wdl
+++ b/adapter_pipelines/ss2_single_sample/adapter.wdl
@@ -83,7 +83,7 @@ workflow AdapterSmartSeq2SingleCell{
   Int max_cromwell_retries = 0
   Boolean add_md5s = false
 
-  String pipeline_tools_version = "se-submit-task-retries"
+  String pipeline_tools_version = "v0.28.2"
 
   call GetInputs as prep {
     input:

--- a/adapter_pipelines/ss2_single_sample/adapter.wdl
+++ b/adapter_pipelines/ss2_single_sample/adapter.wdl
@@ -83,7 +83,7 @@ workflow AdapterSmartSeq2SingleCell{
   Int max_cromwell_retries = 0
   Boolean add_md5s = false
 
-  String pipeline_tools_version = "v0.28.0"
+  String pipeline_tools_version = "se-submit-task-retries"
 
   call GetInputs as prep {
     input:
@@ -229,6 +229,7 @@ workflow AdapterSmartSeq2SingleCell{
       use_caas = use_caas,
       record_http = record_http,
       pipeline_tools_version = pipeline_tools_version,
-      add_md5s = add_md5s
+      add_md5s = add_md5s,
+      max_retries = max_cromwell_retries
   }
 }

--- a/adapter_pipelines/submit.wdl
+++ b/adapter_pipelines/submit.wdl
@@ -9,6 +9,7 @@ task get_metadata {
   Int? individual_request_timeout
   Boolean use_caas
   Boolean record_http
+  Int max_retries = 0
 
   command <<<
     export RECORD_HTTP_REQUESTS="${record_http}"
@@ -29,6 +30,7 @@ task get_metadata {
   >>>
   runtime {
     docker: "gcr.io/broad-dsde-mint-${runtime_environment}/cromwell-metadata:v1.0.0"
+    maxRetries: max_retries
   }
   output {
     File metadata = "metadata.json"
@@ -131,6 +133,7 @@ task stage_files {
   String rb = "}"
   Boolean record_http
   String pipeline_tools_version
+  Int max_retries = 0
 
   command <<<
     set -e
@@ -175,6 +178,7 @@ task stage_files {
 
   runtime {
     docker: "quay.io/humancellatlas/secondary-analysis-pipeline-tools:" + pipeline_tools_version
+    maxRetries: max_retries
   }
   output {
     Array[File] http_requests = glob("request_*.txt")
@@ -247,6 +251,7 @@ workflow submit {
   Boolean record_http = false
   String pipeline_tools_version
   Boolean add_md5s
+  Int max_retries = 0
 
   call get_metadata {
     input:
@@ -258,7 +263,8 @@ workflow submit {
       retry_timeout = retry_timeout,
       individual_request_timeout = individual_request_timeout,
       retry_multiplier = retry_multiplier,
-      retry_max_interval = retry_max_interval
+      retry_max_interval = retry_max_interval,
+      max_retries = max_retries
   }
 
   call create_submission {
@@ -296,7 +302,8 @@ workflow submit {
       retry_multiplier = retry_multiplier,
       retry_max_interval = retry_max_interval,
       record_http = record_http,
-      pipeline_tools_version = pipeline_tools_version
+      pipeline_tools_version = pipeline_tools_version,
+      max_retries = max_retries
   }
 
   call confirm_submission {

--- a/adapter_pipelines/submit_stub/submit.wdl
+++ b/adapter_pipelines/submit_stub/submit.wdl
@@ -32,6 +32,7 @@ workflow submit {
   Boolean record_http = false
   String pipeline_tools_version
   Boolean add_md5s
+  Int max_retries
 
   call submit_stub
 


### PR DESCRIPTION
Note this adds maxRetries to all submit wdl tasks except for the create submission task, since it is not currently idempotent. 

After merging, configure the `max_cromwell_retries` parameter in Lira to override the defaults in pipeline-tools and use cromwell task retries 

Please ensure the following when opening a PR:
- [ ] Added or updated tests
- [ ] Updated documentation
- [ ] Applied style guidelines
- [ ] Considered generalizability beyond our own use case
