### PR TITLE
Test building pipeline-tools image in mintegration test

### DIFF
--- a/adapter_pipelines/ss2_single_sample/adapter.wdl
+++ b/adapter_pipelines/ss2_single_sample/adapter.wdl
@@ -83,7 +83,7 @@ workflow AdapterSmartSeq2SingleCell{
   Int max_cromwell_retries = 0
   Boolean add_md5s = false
 
-  String pipeline_tools_version = "v0.28.2"
+  String pipeline_tools_version = "se-test-build-image-in-mintegration"
 
   call GetInputs as prep {
     input:


### PR DESCRIPTION
PR for testing that the mintegration test successfully builds the pipeline-tools image instead of relying on the quay auto-build trigger. 
