### PR TITLE
Rename cellranger outputs so that they are unique

### DIFF
--- a/adapter_pipelines/Optimus/adapter.wdl
+++ b/adapter_pipelines/Optimus/adapter.wdl
@@ -127,7 +127,7 @@ workflow AdapterOptimus {
   Int max_cromwell_retries = 0
   Boolean add_md5s = false
 
-  String pipeline_tools_version = "v0.32.0"
+  String pipeline_tools_version = "v0.35.0"
 
   call GetInputs as prep {
     input:

--- a/adapter_pipelines/cellranger/adapter.wdl
+++ b/adapter_pipelines/cellranger/adapter.wdl
@@ -243,7 +243,7 @@ workflow Adapter10xCount {
 
   # Rename analysis files so that all the file names are unique. For example, rename
   # "${sample_id}/outs/raw_gene_bc_matrices/${reference}/barcodes.tsv" to "raw_barcodes.tsv" so that
-  # it does not overwrite "${sample_id}/outs/raw_gene_bc_matrices/${reference}/barcodes.tsv"
+  # it does not overwrite "${sample_id}/outs/filtered_gene_bc_matrices/${reference}/barcodes.tsv"
   # when uploading files
   call RenameFiles as output_files {
     input:

--- a/adapter_pipelines/cellranger/adapter.wdl
+++ b/adapter_pipelines/cellranger/adapter.wdl
@@ -175,7 +175,7 @@ workflow Adapter10xCount {
   Int max_cromwell_retries = 0
   Boolean add_md5s = false
 
-  String pipeline_tools_version = "v0.33.0"
+  String pipeline_tools_version = "v0.35.0"
 
   call GetInputs {
     input:

--- a/adapter_pipelines/ss2_single_sample/adapter.wdl
+++ b/adapter_pipelines/ss2_single_sample/adapter.wdl
@@ -83,7 +83,7 @@ workflow AdapterSmartSeq2SingleCell{
   Int max_cromwell_retries = 0
   Boolean add_md5s = false
 
-  String pipeline_tools_version = "v0.33.0"
+  String pipeline_tools_version = "v0.35.0"
 
   call GetInputs as prep {
     input:


### PR DESCRIPTION
Since the HCA upload service overwrites files that have the same name (even if the file paths are unique), change the file names output from cellranger so that they are unique.