### PR TITLE
Fix parameters for submit and stub submit wdl

### DIFF
--- a/adapter_pipelines/Optimus/adapter.wdl
+++ b/adapter_pipelines/Optimus/adapter.wdl
@@ -127,7 +127,7 @@ workflow AdapterOptimus {
   Int max_cromwell_retries = 0
   Boolean add_md5s = false
 
-  String pipeline_tools_version = "v0.35.0"
+  String pipeline_tools_version = "v0.36.0"
 
   call GetInputs as prep {
     input:

--- a/adapter_pipelines/cellranger/adapter.wdl
+++ b/adapter_pipelines/cellranger/adapter.wdl
@@ -175,7 +175,7 @@ workflow Adapter10xCount {
   Int max_cromwell_retries = 0
   Boolean add_md5s = false
 
-  String pipeline_tools_version = "v0.35.0"
+  String pipeline_tools_version = "v0.36.0"
 
   call GetInputs {
     input:
@@ -290,6 +290,7 @@ workflow Adapter10xCount {
       pipeline_tools_version = pipeline_tools_version,
       add_md5s = add_md5s,
       pipeline_version = analysis.pipeline_version,
+      max_retries = max_cromwell_retries,
       # The sorted bam is the largest output. Other outputs will increase space by ~50%.
       # Factor of 2 and addition of 50 GB gives some buffer.
       disk_space = ceil(size(analysis.sorted_bam, "GB") * 2 + 50)

--- a/adapter_pipelines/ss2_single_sample/adapter.wdl
+++ b/adapter_pipelines/ss2_single_sample/adapter.wdl
@@ -83,7 +83,7 @@ workflow AdapterSmartSeq2SingleCell{
   Int max_cromwell_retries = 0
   Boolean add_md5s = false
 
-  String pipeline_tools_version = "v0.35.0"
+  String pipeline_tools_version = "v0.36.0"
 
   call GetInputs as prep {
     input:

--- a/adapter_pipelines/submit_stub/submit.wdl
+++ b/adapter_pipelines/submit_stub/submit.wdl
@@ -32,9 +32,11 @@ workflow submit {
   Boolean record_http = false
   String pipeline_tools_version
   Boolean add_md5s
-  Int max_retries
+  Int max_retries = 0
   # Version of the pipeline, should be included in the pipeline file
   String pipeline_version
+  # Disk space to allocate for stage_files task
+  Int disk_space
 
   call submit_stub
 


### PR DESCRIPTION
-Have cellranger adapter pass in max_cromwell_retries param to submit WDL.
-Make max_cromwell_retries param optional in stub submit WDL.
-Add disk_space param to stub submit WDL.

Mintegration test was failing for skylab PRs because of missing parameter in stub submit WDL.

- [ ] Added or updated tests
- [ ] Updated documentation
- [ ] Applied style guidelines
- [ ] Considered generalizability beyond our own use case
