### PR TITLE
Pass max_retries parameter to cellranger workflow

### DIFF
--- a/adapter_pipelines/Optimus/adapter.wdl
+++ b/adapter_pipelines/Optimus/adapter.wdl
@@ -127,7 +127,7 @@ workflow AdapterOptimus {
   Int max_cromwell_retries = 0
   Boolean add_md5s = false
 
-  String pipeline_tools_version = "v0.41.0"
+  String pipeline_tools_version = "v0.42.0"
 
   call GetInputs as prep {
     input:

--- a/adapter_pipelines/cellranger/adapter.wdl
+++ b/adapter_pipelines/cellranger/adapter.wdl
@@ -151,7 +151,7 @@ workflow Adapter10xCount {
   Int max_cromwell_retries = 0
   Boolean add_md5s = false
 
-  String pipeline_tools_version = "v0.41.0"
+  String pipeline_tools_version = "se-add-cellranger-retries"
 
   call GetInputs {
     input:
@@ -183,7 +183,8 @@ workflow Adapter10xCount {
       fastqs = rename_fastqs.outputs,
       reference_name = reference_name,
       transcriptome_tar_gz = transcriptome_tar_gz,
-      expect_cells = expect_cells
+      expect_cells = expect_cells,
+      max_retries = max_cromwell_retries
   }
 
   call InputsForSubmit {

--- a/adapter_pipelines/cellranger/adapter.wdl
+++ b/adapter_pipelines/cellranger/adapter.wdl
@@ -151,7 +151,7 @@ workflow Adapter10xCount {
   Int max_cromwell_retries = 0
   Boolean add_md5s = false
 
-  String pipeline_tools_version = "se-add-cellranger-retries"
+  String pipeline_tools_version = "v0.42.0"
 
   call GetInputs {
     input:

--- a/adapter_pipelines/ss2_single_sample/adapter.wdl
+++ b/adapter_pipelines/ss2_single_sample/adapter.wdl
@@ -83,7 +83,7 @@ workflow AdapterSmartSeq2SingleCell{
   Int max_cromwell_retries = 0
   Boolean add_md5s = false
 
-  String pipeline_tools_version = "v0.41.0"
+  String pipeline_tools_version = "v0.42.0"
 
   call GetInputs as prep {
     input:


### PR DESCRIPTION
Pass in the max_retries parameter into the Cellranger workflow so that the number of retries can be configured via Lira/the adapter wdl.