### PR TITLE
Update version of HCA CLI

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setup(name='pipeline-tools',
       install_requires=[
           'cromwell-tools',
           'google-cloud-storage>=1.8.0,<2',
-          'hca>=4.4.0,<5',
+          'hca>=4.4.9,<5',
           'hca-metadata-api',
           'mock>=2.0.0,<3',
           'requests>=2.20.0,<3',


### PR DESCRIPTION
Update HCA CLI version to 4.4.9 to fix a potential security vulnerability.