### PR TITLE
Update hca-cli version

### DIFF
--- a/adapter_pipelines/Optimus/adapter.wdl
+++ b/adapter_pipelines/Optimus/adapter.wdl
@@ -127,7 +127,7 @@ workflow AdapterOptimus {
   Int max_cromwell_retries = 0
   Boolean add_md5s = false
 
-  String pipeline_tools_version = "v0.43.0"
+  String pipeline_tools_version = "v0.43.1"
 
   call GetInputs as prep {
     input:

--- a/adapter_pipelines/cellranger/adapter.wdl
+++ b/adapter_pipelines/cellranger/adapter.wdl
@@ -151,7 +151,7 @@ workflow Adapter10xCount {
   Int max_cromwell_retries = 0
   Boolean add_md5s = false
 
-  String pipeline_tools_version = "v0.43.0"
+  String pipeline_tools_version = "v0.43.1"
 
   call GetInputs {
     input:

--- a/adapter_pipelines/ss2_single_sample/adapter.wdl
+++ b/adapter_pipelines/ss2_single_sample/adapter.wdl
@@ -83,7 +83,7 @@ workflow AdapterSmartSeq2SingleCell{
   Int max_cromwell_retries = 0
   Boolean add_md5s = false
 
-  String pipeline_tools_version = "v0.43.0"
+  String pipeline_tools_version = "v0.43.1"
 
   call GetInputs as prep {
     input:

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setup(name='pipeline-tools',
       install_requires=[
           'cromwell-tools',
           'google-cloud-storage>=1.8.0,<2',
-          'hca>=4.4.9,<5',
+          'hca>=4.5.0,<5',
           'hca-metadata-api',
           'mock>=2.0.0,<3',
           'requests>=2.20.0,<3',


### PR DESCRIPTION
### Purpose
Updates version of HCA-cli used in pipeline-tools to at least v4.5.0: https://app.zenhub.com/workspaces/dcp-backlogs-5ac7bcf9465cb172b77760d9/issues/humancellatlas/secondary-analysis/491

---
### Changes
This new version will send a post request to the upload api after files are uploaded successfully via the HCA CLI: 
https://github.com/HumanCellAtlas/dcp-cli/releases/tag/v4.5.0

---
### Review Instructions
- No instructions.

---
### PR Checklist
_Please ensure the following when opening a PR:_

- [ ] This PR added or updated tests.
- [ ] This PR updated docstrings or documentation.
- [ ] This PR applied code style guidelines:
    - [Google style docstrings](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html#example-google) Python code.
    - Mint WDL style guide for WDL.
- [ ] This PR considered generalizability beyond our own use case.

---
### Follow-up Discussions
- No follow-up discussions.
