### PR TITLE
Make the AdapterSS2 wdl accept optional output, e.g. the zarr output.

### DIFF
--- a/adapter_pipelines/Optimus/adapter.wdl
+++ b/adapter_pipelines/Optimus/adapter.wdl
@@ -127,7 +127,7 @@ workflow AdapterOptimus {
   Int max_cromwell_retries = 0
   Boolean add_md5s = false
 
-  String pipeline_tools_version = "v0.43.1"
+  String pipeline_tools_version = "v0.44.0"
 
   call GetInputs as prep {
     input:

--- a/adapter_pipelines/cellranger/adapter.wdl
+++ b/adapter_pipelines/cellranger/adapter.wdl
@@ -151,7 +151,7 @@ workflow Adapter10xCount {
   Int max_cromwell_retries = 0
   Boolean add_md5s = false
 
-  String pipeline_tools_version = "v0.43.1"
+  String pipeline_tools_version = "v0.44.0"
 
   call GetInputs {
     input:

--- a/adapter_pipelines/ss2_single_sample/adapter.wdl
+++ b/adapter_pipelines/ss2_single_sample/adapter.wdl
@@ -177,18 +177,21 @@ workflow AdapterSmartSeq2SingleCell{
           "value": stranded
         }
       ],
-      outputs = flatten([[
-        analysis.aligned_bam,
-        analysis.bam_index,
-        analysis.insert_size_metrics,
-        analysis.quality_distribution_metrics,
-        analysis.quality_by_cycle_metrics,
-        analysis.bait_bias_summary_metrics,
-        analysis.rna_metrics,
-        analysis.aligned_transcriptome_bam,
-        analysis.rsem_gene_results,
-        analysis.rsem_isoform_results
-      ], analysis.group_results, analysis.zarr_output_files]),
+      outputs = flatten(
+        select_all(
+          [[analysis.aligned_bam,
+            analysis.bam_index,
+            analysis.insert_size_metrics,
+            analysis.quality_distribution_metrics,
+            analysis.quality_by_cycle_metrics,
+            analysis.bait_bias_summary_metrics,
+            analysis.rna_metrics,
+            analysis.aligned_transcriptome_bam,
+            analysis.rsem_gene_results,
+            analysis.rsem_isoform_results
+           ], analysis.group_results, analysis.zarr_output_files]
+        )
+      ),
       format_map = format_map,
       submit_url = submit_url,
       cromwell_url = cromwell_url,

--- a/adapter_pipelines/ss2_single_sample/adapter.wdl
+++ b/adapter_pipelines/ss2_single_sample/adapter.wdl
@@ -83,7 +83,7 @@ workflow AdapterSmartSeq2SingleCell{
   Int max_cromwell_retries = 0
   Boolean add_md5s = false
 
-  String pipeline_tools_version = "v0.43.1"
+  String pipeline_tools_version = "v0.44.0"
 
   call GetInputs as prep {
     input:

--- a/adapter_pipelines/ss2_single_sample/options.json
+++ b/adapter_pipelines/ss2_single_sample/options.json
@@ -1,5 +1,5 @@
 {
   "monitoring_script": "gs://hca-dcp-mint-test-data/accessories/monitoring/smartseq2/monitoring.sh",
-  "read_from_cache": true,
+  "read_from_cache": false,
   "backend": "PAPIv2"
 }

--- a/adapter_pipelines/ss2_single_sample/options.json
+++ b/adapter_pipelines/ss2_single_sample/options.json
@@ -1,5 +1,5 @@
 {
   "monitoring_script": "gs://hca-dcp-mint-test-data/accessories/monitoring/smartseq2/monitoring.sh",
-  "read_from_cache": false,
+  "read_from_cache": true,
   "backend": "PAPIv2"
 }


### PR DESCRIPTION
### Purpose
_Please explain the purpose of this PR and include links to any GitHub issues that it fixes:_

- https://app.zenhub.com/workspaces/dcp-backlogs-5ac7bcf9465cb172b77760d9/issues/humancellatlas/secondary-analysis/502
---
### Changes
_Please list out what major changes were made in this PR to address the issue:_

- Make the AdapterSS2 wdl accept optional output, e.g. the zarr output, by using the `select_all` feature of the WDL: https://github.com/openwdl/wdl/blob/master/versions/1.0/SPEC.md#arrayx-select_allarrayx
---
### Review Instructions
_Please provide instructions about how should a reviewer test/verify the changes in this PR:_

- No instructions.

---
### PR Checklist
_Please ensure the following when opening a PR:_

- [ ] This PR added or updated tests.
- [ ] This PR updated docstrings or documentation.
- [ ] This PR applied code style guidelines:
    - [Google style docstrings](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html#example-google) Python code.
    - Mint WDL style guide for WDL.
- [ ] This PR considered generalizability beyond our own use case.

---
### Follow-up Discussions
_Please append follow-up discussions and issues during the review process below:_

Without the changes this PR made, we will get error like:
```
"Unable to build WOM node for WdlWorkflowCall 'submit': Cannot build expression for 'AdapterSmartSeq2SingleCell.submit.outputs = flatten([[analysis.aligned_bam, analysis.bam_index, analysis.insert_size_metrics, analysis.quality_distribution_metrics, analysis.quality_by_cycle_metrics, analysis.bait_bias_summary_metrics, analysis.rna_metrics, analysis.aligned_transcriptome_bam, analysis.rsem_gene_results, analysis.rsem_isoform_results], analysis.group_results, analysis.zarr_output_files])': flatten requires an Array[Array[_]] argument but instead got Array[Array[File]?]"
```
