### PR TITLE
Update Optimus Adapter workflow 

### DIFF
--- a/adapter_pipelines/Optimus/adapter.wdl
+++ b/adapter_pipelines/Optimus/adapter.wdl
@@ -219,6 +219,9 @@ workflow AdapterOptimus {
       record_http = record_http,
       pipeline_tools_version = pipeline_tools_version,
       add_md5s = add_md5s,
-      pipeline_version = analysis.pipeline_version
+      pipeline_version = analysis.pipeline_version,
+      # The disk space value here is still an experiment value, need to 
+      # be optimized based on historical data by CBs
+      disk_space = ceil(size(analysis.bam, "GB") * 2 + 50)
   }
 }

--- a/adapter_pipelines/Optimus/adapter.wdl
+++ b/adapter_pipelines/Optimus/adapter.wdl
@@ -38,7 +38,7 @@ task GetInputs {
     String sample_id = read_string("sample_id.txt")
     Array[File] r1_fastq = read_lines("r1.txt")
     Array[File] r2_fastq = read_lines("r2.txt")
-    Array[File] i1_fastq = read_lines("i1.txt")
+    Array[File]? i1_fastq = read_lines("i1.txt")
     Array[File] http_requests = glob("request_*.txt")
     Array[File] http_responses = glob("response_*.txt")
   }
@@ -61,21 +61,21 @@ task InputsForSubmit {
       inputs.append({"name": "r1_fastq", "value": "${sep=', ' r1_fastq}"})
       inputs.append({"name": "r2_fastq", "value": "${sep=', ' r2_fastq}"})
 
-      i1_fastq = "${sep=', ' i1_fastq}"
-      if i1_fastq:
-          print('I1 fastq {i1_fastq} is provided'.format(i1_fastq))
-          inputs.append({"name": "i1_fastq", "value": i1_fastq})
+      i1_fastq_value = "${sep=', ' i1_fastq}"
+      if i1_fastq_value:
+          print('I1 fastq {} provided'.format(i1_fastq_value))
+          inputs.append({"name": "i1_fastq", "value": i1_fastq_value})
 
       print('other inputs')
       with open('${write_objects(other_inputs)}') as f:
           keys = f.readline().strip().split('\t')
           for line in f:
               values = line.strip().split('\t')
-              input = {}
+              input_map = {}
               for i, key in enumerate(keys):
-                  input[key] = values[i]
-              print(input)
-              inputs.append(input)
+                  input_map[key] = values[i]
+              print(input_map)
+              inputs.append(input_map)
 
       print('write inputs.tsv')
       with open('inputs.tsv', 'w') as f:

--- a/adapter_pipelines/Optimus/adapter.wdl
+++ b/adapter_pipelines/Optimus/adapter.wdl
@@ -45,9 +45,9 @@ task GetInputs {
 }
 
 task InputsForSubmit {
-    Array[File] r1_fastq
-    Array[File] r2_fastq
-    Array[File] i1_fastq
+    Array[String] r1_fastq
+    Array[String] r2_fastq
+    Array[String]? i1_fastq
     Array[Object] other_inputs
     String pipeline_tools_version
 
@@ -60,7 +60,11 @@ task InputsForSubmit {
       print('fastq_files')
       inputs.append({"name": "r1_fastq", "value": "${sep=', ' r1_fastq}"})
       inputs.append({"name": "r2_fastq", "value": "${sep=', ' r2_fastq}"})
-      inputs.append({"name": "i1_fastq", "value": "${sep=', ' i1_fastq}"})
+
+      i1_fastq = "${sep=', ' i1_fastq}"
+      if i1_fastq:
+          print('I1 fastq {i1_fastq} is provided'.format(i1_fastq))
+          inputs.append({"name": "i1_fastq", "value": i1_fastq})
 
       print('other inputs')
       with open('${write_objects(other_inputs)}') as f:
@@ -126,7 +130,11 @@ workflow AdapterOptimus {
   Int max_cromwell_retries = 0
   Boolean add_md5s = false
 
+<<<<<<< HEAD
   String pipeline_tools_version = "v0.46.2"
+=======
+  String pipeline_tools_version = "rex-adapter-optimus"
+>>>>>>> a933de3... Fix a bug with the GetInputsforSubmit task in AdapterOptimus.
 
   call GetInputs as prep {
     input:

--- a/adapter_pipelines/Optimus/adapter.wdl
+++ b/adapter_pipelines/Optimus/adapter.wdl
@@ -107,10 +107,13 @@ workflow AdapterOptimus {
   File ref_genome_fasta  # genome fasta file
   String fastq_suffix = ".gz"  # add this suffix to fastq files for picard
   
-  # Note: This "Empty" is a workaround in WDL-draft to simulate a "None" type
+  # Note: This "None" is a workaround in WDL-draft to simulate a "None" type
   # once the official "None" type is introduced (probably in WDL 2.0)
-  # we should consider replace this workaround
-  Array[File]? Empty
+  # we should consider replace this dummy None with the built-in None!
+  # 
+  # Also, to properly use this dummy None, we should avoid passing in any
+  # inputs that could possibly override this
+  Array[File]? None
 
   # Submission
   File format_map
@@ -136,11 +139,7 @@ workflow AdapterOptimus {
   Int max_cromwell_retries = 0
   Boolean add_md5s = false
 
-<<<<<<< HEAD
-  String pipeline_tools_version = "v0.46.2"
-=======
-  String pipeline_tools_version = "rex-adapter-optimus"
->>>>>>> a933de3... Fix a bug with the GetInputsforSubmit task in AdapterOptimus.
+  String pipeline_tools_version = "v0.47.0"
 
   call GetInputs as prep {
     input:
@@ -159,7 +158,7 @@ workflow AdapterOptimus {
     input:
       r1_fastq = prep.r1_fastq,
       r2_fastq = prep.r2_fastq,
-      i1_fastq = if (length(prep.i1_fastq) <= 0) then Empty else prep.i1_fastq,
+      i1_fastq = if (length(prep.i1_fastq) <= 0) then None else prep.i1_fastq,
       sample_id = prep.sample_id,
       whitelist = whitelist,
       tar_star_reference = tar_star_reference,

--- a/adapter_pipelines/Optimus/adapter.wdl
+++ b/adapter_pipelines/Optimus/adapter.wdl
@@ -44,7 +44,7 @@ task GetInputs {
   }
 }
 
-task inputs_for_submit {
+task InputsForSubmit {
     Array[File] r1_fastq
     Array[File] r2_fastq
     Array[File] i1_fastq
@@ -154,7 +154,7 @@ workflow AdapterOptimus {
       fastq_suffix = fastq_suffix
   }
 
-  call inputs_for_submit {
+  call InputsForSubmit {
     input:
       r1_fastq = prep.r1_fastq,
       r2_fastq = prep.r2_fastq,
@@ -184,19 +184,22 @@ workflow AdapterOptimus {
       pipeline_tools_version = pipeline_tools_version
   }
 
-  Array[Object] inputs = read_objects(inputs_for_submit.inputs)
+  Array[Object] inputs = read_objects(InputsForSubmit.inputs)
 
   call submit_wdl.submit {
     input:
       inputs = inputs,
-      outputs = [
-        analysis.bam,
-        analysis.matrix,
-        analysis.matrix_row_index,
-        analysis.matrix_col_index,
-        analysis.cell_metrics,
-        analysis.gene_metrics
-      ],
+      outputs = flatten(
+        select_all(
+          [[analysis.bam,
+            analysis.matrix,
+            analysis.matrix_row_index,
+            analysis.matrix_col_index,
+            analysis.cell_metrics,
+            analysis.gene_metrics
+        ], analysis.zarr_output_files]
+        )
+      ),
       format_map = format_map,
       submit_url = submit_url,
       cromwell_url = cromwell_url,

--- a/adapter_pipelines/Optimus/adapter_example_static.json
+++ b/adapter_pipelines/Optimus/adapter_example_static.json
@@ -1,8 +1,8 @@
 {
-  "AdapterOptimus.whitelist": "gs://hca-dcp-mint-test-data/10x/whitelist/737K-august-2016.txt",
-  "AdapterOptimus.tar_star_reference": "gs://hca-dcp-mint-test-data/reference/demo/star.tar",
-  "AdapterOptimus.annotations_gtf": "gs://hca-dcp-mint-test-data/reference/demo/hg19_ds/GSM1629193_hg19_ERCC.gtf.gz",
-  "AdapterOptimus.ref_genome_fasta": "gs://hca-dcp-mint-test-data/reference/demo/chr21.fa",
+  "AdapterOptimus.whitelist": "gs://hca-dcp-sc-pipelines-test-data/whitelists/737K-august-2016.txt",
+  "AdapterOptimus.tar_star_reference": "gs://hca-dcp-sc-pipelines-test-data/alignmentReferences/optimusGencodeV27/buildReference/output_bucket/star_primary_gencode_v27.tar",
+  "AdapterOptimus.annotations_gtf": "gs://hca-dcp-sc-pipelines-test-data/alignmentReferences/optimusGencodeV27/gencode.v27.primary_assembly.annotation.gtf.gz",
+  "AdapterOptimus.ref_genome_fasta": "gs://hca-dcp-sc-pipelines-test-data/alignmentReferences/optimusGencodeV27/GRCh38.primary_assembly.genome.fa",
   "AdapterOptimus.reference_bundle": "bf51d668-3e14-4843-9bc7-5d676fdf0e01",
   "AdapterOptimus.format_map": "gs://hca-dcp-mint-test-data/adapters/file_format_map.json",
   "AdapterOptimus.method": "Optimus",

--- a/adapter_pipelines/Optimus/options_no_caching.json
+++ b/adapter_pipelines/Optimus/options_no_caching.json
@@ -1,5 +1,6 @@
 {
   "monitoring_script": "gs://hca-dcp-mint-test-data/accessories/monitoring/optimus/monitor.sh",
   "read_from_cache":false,
-  "write_to_cache":false
+  "write_to_cache":false,
+  "backend": "PAPIv2"
 }

--- a/adapter_pipelines/cellranger/adapter.wdl
+++ b/adapter_pipelines/cellranger/adapter.wdl
@@ -90,11 +90,11 @@ task InputsForSubmit {
           keys = f.readline().strip().split('\t')
           for line in f:
               values = line.strip().split('\t')
-              input = {}
+              input_map = {}
               for i, key in enumerate(keys):
-                  input[key] = values[i]
-              print(input)
-              inputs.append(input)
+                  input_map[key] = values[i]
+              print(input_map)
+              inputs.append(input_map)
 
       print('expect cells')
       if "${expect_cells}":

--- a/adapter_pipelines/cellranger/adapter.wdl
+++ b/adapter_pipelines/cellranger/adapter.wdl
@@ -150,7 +150,7 @@ workflow Adapter10xCount {
   Int max_cromwell_retries = 0
   Boolean add_md5s = false
 
-  String pipeline_tools_version = "v0.46.2"
+  String pipeline_tools_version = "rex-adapter-optimus"
 
   call GetInputs {
     input:

--- a/adapter_pipelines/cellranger/adapter.wdl
+++ b/adapter_pipelines/cellranger/adapter.wdl
@@ -150,7 +150,7 @@ workflow Adapter10xCount {
   Int max_cromwell_retries = 0
   Boolean add_md5s = false
 
-  String pipeline_tools_version = "rex-adapter-optimus"
+  String pipeline_tools_version = "v0.47.0"
 
   call GetInputs {
     input:

--- a/adapter_pipelines/ss2_single_sample/adapter.wdl
+++ b/adapter_pipelines/ss2_single_sample/adapter.wdl
@@ -82,7 +82,7 @@ workflow AdapterSmartSeq2SingleCell{
   Int max_cromwell_retries = 0
   Boolean add_md5s = false
 
-  String pipeline_tools_version = "v0.46.2"
+  String pipeline_tools_version = "rex-adapter-optimus"
 
   call GetInputs as prep {
     input:

--- a/adapter_pipelines/ss2_single_sample/adapter.wdl
+++ b/adapter_pipelines/ss2_single_sample/adapter.wdl
@@ -82,7 +82,7 @@ workflow AdapterSmartSeq2SingleCell{
   Int max_cromwell_retries = 0
   Boolean add_md5s = false
 
-  String pipeline_tools_version = "rex-adapter-optimus"
+  String pipeline_tools_version = "v0.47.0"
 
   call GetInputs as prep {
     input:

--- a/pipeline_tools/get_analysis_workflow_metadata.py
+++ b/pipeline_tools/get_analysis_workflow_metadata.py
@@ -71,6 +71,7 @@ def get_metadata(cromwell_url, workflow_id, http_requests):
         
     base_url = cromwell_url.strip('/')
     url = '{0}/api/workflows/v1/{1}/metadata?expandSubWorkflows=true'.format(base_url, workflow_id)
+
     response = http_requests.get(url, headers=headers, before=log_before(workflow_id))
     with open('metadata.json', 'w') as f:
         json.dump(response.json(), f, indent=2)

--- a/pipeline_tools/get_analysis_workflow_metadata.py
+++ b/pipeline_tools/get_analysis_workflow_metadata.py
@@ -59,10 +59,24 @@ def get_metadata(cromwell_url, workflow_id, http_requests):
     def log_before(workflow_id):
         print('Getting metadata for workflow {}'.format(workflow_id))
 
-    headers = get_auth_headers()
-    base_url = cromwell_url.strip('/')
-    url = '{0}/api/workflows/v1/{1}/metadata?expandSubWorkflows=true'.format(base_url, workflow_id)
-    response = http_requests.get(url, headers=headers, before=log_before(workflow_id))
+    cromwell_url = cromwell_url
+
+    if use_caas:
+        json_credentials = caas_key_file or "/cromwell-metadata/caas_key.json"
+        headers = cromwell_tools.generate_auth_header_from_key_file(json_credentials)
+        auth = None
+        # There is an issue with the current CromIAM that huge response content can
+        # break the gzip compressing and session, which will raise an error:
+        # `requests.exceptions.ChunkedEncodingError`. Check here: 
+        # https://github.com/broadinstitute/cromwell/issues/4708 for the details. 
+        # As a workaround, we need to pass `Accept-Encoding: identity` to the header
+        # to force disabling the compressing
+        headers['Accept-Encoding'] = 'identity'
+    else:
+        headers = None
+        auth = get_auth()
+    url = '{0}/{1}/metadata?expandSubWorkflows=true'.format(cromwell_url, workflow_id)
+    response = http_requests.get(url, auth=auth, headers=headers, before=log_before(workflow_id))
     with open('metadata.json', 'w') as f:
         json.dump(response.json(), f, indent=2)
 

--- a/pipeline_tools/input_utils.py
+++ b/pipeline_tools/input_utils.py
@@ -208,7 +208,7 @@ def create_optimus_input_tsv(uuid, version, dss_url):
         TSV of input file cloud paths
 
     Raises:
-        optimus_utils.LaneMissingFileError if any fastqs are missing
+        optimus_utils.LaneMissingFileError if any non-optional fastqs are missing
     """
     # Get bundle manifest
     print('Getting bundle manifest for id {0}, version {1}'.format(uuid, version))
@@ -226,13 +226,16 @@ def create_optimus_input_tsv(uuid, version, dss_url):
     r2_urls = optimus_utils.get_fastqs_for_read_index(lane_to_fastqs, 'read2')
     i1_urls = optimus_utils.get_fastqs_for_read_index(lane_to_fastqs, 'index1')
 
-    print('Writing r1.txt, r2.txt, and i1.txt')
+    print('Writing r1.txt, r2.txt, and optionally i1.txt')
     with open('r1.txt', 'w') as f:
         for url in r1_urls:
             f.write(url + '\n')
     with open('r2.txt', 'w') as f:
         for url in r2_urls:
             f.write(url + '\n')
+    
+    # Always generate the i1.txt, if there are no i1 fastq files,
+    # the content of this file will be empty
     with open('i1.txt', 'w') as f:
         for url in i1_urls:
             f.write(url + '\n')

--- a/pipeline_tools/input_utils.py
+++ b/pipeline_tools/input_utils.py
@@ -236,10 +236,6 @@ def create_optimus_input_tsv(uuid, version, dss_url):
     with open('i1.txt', 'w') as f:
         for url in i1_urls:
             f.write(url + '\n')
-    with open('lanes.txt', 'w') as f:
-        lane_numbers = sorted(lane_to_fastqs.keys())
-        for l in lane_numbers:
-            f.write(str(l))
 
     sample_id = get_sample_id(primary_bundle)
     print('Writing sample ID to sample_id.txt')


### PR DESCRIPTION
### Purpose
_Please explain the purpose of this PR and include links to any GitHub issues that it fixes:_

- https://app.zenhub.com/workspaces/dcp-backlogs-5ac7bcf9465cb172b77760d9/issues/humancellatlas/secondary-analysis/368
---
### Changes
_Please list out what major changes were made in this PR to address the issue:_

- Update the AdapterOptimus WDL so it expects Zarr outputs from the Optimus analysis pipeline.
- Update the options of AdapterOptimus WDL.
- Update the `get_workflow_metadata.py` so it bypasses the error in CaaS when the workflow's content of metadata is too large.

---
### Review Instructions
_Please provide instructions about how should a reviewer test/verify the changes in this PR:_

#### Happy Path 1: 4k_pbmc with i1

~~- Please go to https://job-manager.caas-prod.broadinstitute.org/jobs/9fad12e1-ae75-4b41-bc6f-94d2b707f191 to check the workflow succeeded, which was kicked off for testing this adapter workflow.~~
~~- Please go to https://integration.data.humancellatlas.org/explore/files?filter=%5B%7B%22facetName%22%3A%22project%22%2C%22terms%22%3A%5B%22Optimus+Pipeline+Testing+Dataset+4kpbmc%22%5D%7D%5D and verify that the results of this run are shown properly.~~
~~- Please note the inputs to the above testing workflow is the full 4k_pbmc dataset.~~

- Please go to https://job-manager.caas-prod.broadinstitute.org/jobs/48506c11-7851-4391-b589-e1518646500b to check the workflow succeeded, which was kicked off for testing this adapter workflow.
- Please note the inputs to the above testing workflow is the full 4k_pbmc dataset.

#### Unhappy Path: 4k_pbmc without i1
~~- Please take a look at https://job-manager.caas-prod.broadinstitute.org/jobs/8be84893-6871-494b-8bc8-aa0c56b9fb40~~
~~- It ran through the `prep` task, which means the input preparation is OK. It failed at the analysis step.~~

- Please take a look at https://job-manager.caas-prod.broadinstitute.org/jobs/fb323315-ce47-4ac3-b482-f7692b96f76a to check the workflow succeeded, which was kicked off for testing this adapter workflow.
- It ran through the `prep` task, which means the input preparation is OK. It also invokes the "AttachBarcodesNoIndex" in Optimus analysis workflow, which indicates the `i1_fastq` was not passed in to the analysis pipeline as expected.

#### happy Path 2: 8k_pbmc with i1

Synced up with @kishorikonwar and decided to not un 8k dataset for this PR since it's captured by the test in Skylab already!

---
### PR Checklist
_Please ensure the following when opening a PR:_

- [ ] This PR added or updated tests.
- [ ] This PR updated docstrings or documentation.
- [ ] This PR applied code style guidelines:
    - [Google style docstrings](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html#example-google) Python code.
    - Mint WDL style guide for WDL.
- [x] This PR considered generalizability beyond our own use case.

---
### Follow-up Discussions
_Please append follow-up discussions and issues during the review process below:_

@pshapiro4broad suggested a better way to mimic `None` in WDL draft - 2, the latest change should reflect that. correspsonding tests:
- No index: https://job-manager.caas-prod.broadinstitute.org/jobs/dbd0aa72-0d37-44a1-906c-a76c37059423 (It ran thru the testing step but failed at a tep that talking to the external service, due to a PAPI v2 error, which shouldn't block us from merging!)
- With index: https://job-manager.caas-prod.broadinstitute.org/jobs/5689c99a-5bf4-417e-a99c-97796199ab4c
