### PR TITLE
Replace setup.py dependency_links

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,4 +13,4 @@ COPY . .
 # Get latest setuptools because metadata-api installation fails without at least 40.1.0
 RUN pip install -U setuptools
 
-RUN pip install . --process-dependency-links --trusted-host github.com
+RUN pip install . --trusted-host github.com

--- a/setup.py
+++ b/setup.py
@@ -19,13 +19,13 @@ setup(name='pipeline-tools',
           'google-auth>=1.6.1,<2',
           'google-cloud-storage>=1.10.0,<2',
           'hca>=4.5.0,<5',
-          'hca-metadata-api',
           'mock>=2.0.0,<3',
           'requests>=2.20.0,<3',
           'requests-mock>=1.5.2,<2',
           'setuptools_scm>=2.0.0,<3',
           'tenacity>=4.10.0,<5',
-          'PyJWT==1.6.4'
+          'PyJWT==1.6.4',
+          'hca-metadata-api @ git+git://github.com/HumanCellAtlas/metadata-api@release/1.0b4'
       ],
       entry_points={
           'console_scripts': [
@@ -37,12 +37,5 @@ setup(name='pipeline-tools',
               'confirm-submission=pipeline_tools.confirm_submission:main'
           ]
       },
-      # FIXME: DEPRECATION: Dependency Links processing has been deprecated and will be removed in a future release.
-      dependency_links=[
-          # FIXME: install hca-metadata-api from PyPI once it is available (shortly)
-          # Pin to a specific commit of the hca-metadata-api so we won't be broken by changes to that repo before it's
-          # available on PyPI
-          'git+git://github.com/HumanCellAtlas/metadata-api@release/1.0b4#egg=hca-metadata-api-0.0.1'
-      ],
       include_package_data=True
       )


### PR DESCRIPTION
### Purpose
The process-dependency-links flag has been deprecated in pip v19.0. This is causing the automated docker builds in Quay to fail for pipeline-tools 🙀 

---

### Changes
Remove `dependency_links` and add the URL to `install_requires` in setup.py

---
### Review Instructions
This PR can be reviewed by checking out this branch and building the docker image locally. You may need to upgrade the version of pip. 

---
### PR Checklist
_Please ensure the following when opening a PR:_

- [ ] This PR added or updated tests.
- [ ] This PR updated docstrings or documentation.
- [ ] This PR applied code style guidelines:
    - [Google style docstrings](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html#example-google) Python code.
    - Mint WDL style guide for WDL.
- [ ] This PR considered generalizability beyond our own use case.

---
### Follow-up Discussions
- No follow-up discussions.
