### PR TITLE
Remove unused lanes.txt file

### DIFF
--- a/pipeline_tools/input_utils.py
+++ b/pipeline_tools/input_utils.py
@@ -236,10 +236,6 @@ def create_optimus_input_tsv(uuid, version, dss_url):
     with open('i1.txt', 'w') as f:
         for url in i1_urls:
             f.write(url + '\n')
-    with open('lanes.txt', 'w') as f:
-        lane_numbers = sorted(lane_to_fastqs.keys())
-        for l in lane_numbers:
-            f.write(str(l))
 
     sample_id = get_sample_id(primary_bundle)
     print('Writing sample ID to sample_id.txt')


### PR DESCRIPTION
### Purpose
The Optimus adapter code writes lane index information to a file that does not get consumed anywhere in the adapter pipeline: https://github.com/HumanCellAtlas/pipeline-tools/blob/master/pipeline_tools/input_utils.py#L239

This is left over from a previous implementation and should be removed.


---
### Changes
Removed unused code

---
### Review Instructions
- No instructions.

---
### PR Checklist
_Please ensure the following when opening a PR:_

- [ ] This PR added or updated tests.
- [ ] This PR updated docstrings or documentation.
- [ ] This PR applied code style guidelines:
    - [Google style docstrings](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html#example-google) Python code.
    - Mint WDL style guide for WDL.
- [ ] This PR considered generalizability beyond our own use case.

---
### Follow-up Discussions
- No follow-up discussions.
