### PR TITLE
Fix payload for adding file references

### DIFF
--- a/adapter_pipelines/Optimus/adapter.wdl
+++ b/adapter_pipelines/Optimus/adapter.wdl
@@ -139,7 +139,7 @@ workflow AdapterOptimus {
   Int max_cromwell_retries = 0
   Boolean add_md5s = false
 
-  String pipeline_tools_version = "se-fix-file-payload"
+  String pipeline_tools_version = "v0.48.1"
 
   call GetInputs as prep {
     input:

--- a/adapter_pipelines/Optimus/adapter.wdl
+++ b/adapter_pipelines/Optimus/adapter.wdl
@@ -139,7 +139,7 @@ workflow AdapterOptimus {
   Int max_cromwell_retries = 0
   Boolean add_md5s = false
 
-  String pipeline_tools_version = "v0.48.0"
+  String pipeline_tools_version = "se-fix-file-payload"
 
   call GetInputs as prep {
     input:

--- a/adapter_pipelines/cellranger/adapter.wdl
+++ b/adapter_pipelines/cellranger/adapter.wdl
@@ -150,7 +150,7 @@ workflow Adapter10xCount {
   Int max_cromwell_retries = 0
   Boolean add_md5s = false
 
-  String pipeline_tools_version = "se-fix-file-payload"
+  String pipeline_tools_version = "v0.48.1"
 
   call GetInputs {
     input:

--- a/adapter_pipelines/cellranger/adapter.wdl
+++ b/adapter_pipelines/cellranger/adapter.wdl
@@ -150,7 +150,7 @@ workflow Adapter10xCount {
   Int max_cromwell_retries = 0
   Boolean add_md5s = false
 
-  String pipeline_tools_version = "v0.48.0"
+  String pipeline_tools_version = "se-fix-file-payload"
 
   call GetInputs {
     input:

--- a/adapter_pipelines/ss2_single_sample/adapter.wdl
+++ b/adapter_pipelines/ss2_single_sample/adapter.wdl
@@ -82,7 +82,7 @@ workflow AdapterSmartSeq2SingleCell{
   Int max_cromwell_retries = 0
   Boolean add_md5s = false
 
-  String pipeline_tools_version = "se-fix-file-payload"
+  String pipeline_tools_version = "v0.48.1"
 
   call GetInputs as prep {
     input:

--- a/adapter_pipelines/ss2_single_sample/adapter.wdl
+++ b/adapter_pipelines/ss2_single_sample/adapter.wdl
@@ -82,7 +82,7 @@ workflow AdapterSmartSeq2SingleCell{
   Int max_cromwell_retries = 0
   Boolean add_md5s = false
 
-  String pipeline_tools_version = "v0.48.0"
+  String pipeline_tools_version = "se-fix-file-payload"
 
   call GetInputs as prep {
     input:

--- a/pipeline_tools/create_envelope.py
+++ b/pipeline_tools/create_envelope.py
@@ -312,12 +312,12 @@ def add_file_reference(file_ref, file_refs_url, auth_headers, http_requests):
     Raises:
         requests.HTTPError: For 4xx errors or 5xx errors beyond timeout.
     """
-    file_name = file_ref['file_core']['file_name']
-    print('Adding file: {0} to the file reference.'.format(file_name))
+    # Format payload for ingest file reference API endpoint
     file_payload = {
-        'fileName': file_name,
+        'fileName': file_ref['file_core']['file_name'],
         'content': file_ref
     }
+    print('Adding file reference: {}'.format(file_payload))
     response = http_requests.put(file_refs_url, headers=auth_headers, json=file_payload)
     return response.json()
 

--- a/pipeline_tools/create_envelope.py
+++ b/pipeline_tools/create_envelope.py
@@ -312,8 +312,13 @@ def add_file_reference(file_ref, file_refs_url, auth_headers, http_requests):
     Raises:
         requests.HTTPError: For 4xx errors or 5xx errors beyond timeout.
     """
-    print('Adding file: {0} to the file reference.'.format(file_ref['file_core']['file_name']))
-    response = http_requests.put(file_refs_url, headers=auth_headers, json=file_ref)
+    file_name = file_ref['file_core']['file_name']
+    print('Adding file: {0} to the file reference.'.format(file_name))
+    file_payload = {
+        'fileName': file_name,
+        'content': file_ref
+    }
+    response = http_requests.put(file_refs_url, headers=auth_headers, json=file_payload)
     return response.json()
 
 


### PR DESCRIPTION
### Purpose
When adding file references via the ingest API, the payload needs to include the "fileName" and "content" keys (the file schema is nested under content).

---
### Changes
Update the payload format for adding file references.

---
### Review Instructions
- The integration test should pass
- Content key is not `null` in the submission envelope's file json: https://api.ingest.integration.data.humancellatlas.org/submissionEnvelopes/5c8bd4d766ad970007f40f67/files

---
### PR Checklist
_Please ensure the following when opening a PR:_

- [ ] This PR added or updated tests.
- [ ] This PR updated docstrings or documentation.
- [ ] This PR applied code style guidelines:
    - [Google style docstrings](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html#example-google) Python code.
    - Mint WDL style guide for WDL.
- [ ] This PR considered generalizability beyond our own use case.

---
### Follow-up Discussions
- No follow-up discussions.
