### PR TITLE
Pass empty drops output to submit

### DIFF
--- a/adapter_pipelines/Optimus/adapter.wdl
+++ b/adapter_pipelines/Optimus/adapter.wdl
@@ -209,7 +209,8 @@ workflow AdapterOptimus {
             analysis.matrix_row_index,
             analysis.matrix_col_index,
             analysis.cell_metrics,
-            analysis.gene_metrics
+            analysis.gene_metrics,
+            analysis.cell_calls,
         ], analysis.zarr_output_files]
         )
       ),


### PR DESCRIPTION
### Purpose
Fix https://broadinstitute.atlassian.net/jira/software/projects/GH/boards/530?selectedIssue=GH-175


### Changes
Pass the empty drops output from the analysis pipeline into the submit wdl so that it is included in the results bundles created in the data store.

---
### Review Instructions
Confirm that the analysis outputs are correctly passed into the submit wdl: https://github.com/HumanCellAtlas/skylab/blob/master/pipelines/optimus/Optimus.wdl#L221

---
### PR Checklist
_Please ensure the following when opening a PR:_

- [ ] This PR added or updated tests.
- [ ] This PR updated docstrings or documentation.
- [ ] This PR applied code style guidelines:
    - [Google style docstrings](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html#example-google) Python code.
    - Mint WDL style guide for WDL.
- [ ] This PR considered generalizability beyond our own use case.

---
### Follow-up Discussions
_Please append follow-up discussions and issues during the review process below:_

- No follow-up discussions.
