### PR TITLE
Add single-end SS2 pipeline

### DIFF
--- a/adapter_pipelines/Optimus/adapter.wdl
+++ b/adapter_pipelines/Optimus/adapter.wdl
@@ -139,7 +139,7 @@ workflow AdapterOptimus {
   Int max_cromwell_retries = 0
   Boolean add_md5s = false
 
-  String pipeline_tools_version = "v0.50.2"
+  String pipeline_tools_version = "v0.51.0"
 
   call GetInputs as prep {
     input:

--- a/adapter_pipelines/cellranger/adapter.wdl
+++ b/adapter_pipelines/cellranger/adapter.wdl
@@ -150,7 +150,7 @@ workflow Adapter10xCount {
   Int max_cromwell_retries = 0
   Boolean add_md5s = false
 
-  String pipeline_tools_version = "v0.50.2"
+  String pipeline_tools_version = "v0.51.0"
 
   call GetInputs {
     input:

--- a/adapter_pipelines/ss2_single_end/README.md
+++ b/adapter_pipelines/ss2_single_end/README.md
@@ -1,0 +1,20 @@
+# Overview
+
+This directory contains an adapter pipeline used by the Secondary Analysis Service to run the SmartSeq2SingleSample pipeline on single-end data.
+
+# Files
+
+* adapter.wdl
+The adapter pipeline, which parses a bundle manifest from the Data Storage Service, runs the Smart-seq2 analysis pipeline, then runs the submission pipeline to submit the results to the Ingest Service.
+
+* adapter_example_static.json and adapter_example_bundle_specific.json
+Example inputs to use when running these pipelines, split into two files, one for inputs that vary from bundle to bundle, and the other for inputs that stay the same for every run.
+
+* adapter_example_static_demo.json
+A smaller set of static (reference) inputs that run faster and can be used for demonstration and testing purposes.
+
+* dependencies.json
+The locations of the wdls imported by the SmartSeq2Singlesample workflow
+
+* options.json
+Options file to use when running workflow.

--- a/adapter_pipelines/ss2_single_end/adapter.wdl
+++ b/adapter_pipelines/ss2_single_end/adapter.wdl
@@ -81,7 +81,7 @@ workflow AdapterSmartSeq2SingleCellUnpaired {
   Int max_cromwell_retries = 0
   Boolean add_md5s = false
 
-  String pipeline_tools_version = "v0.51.0"
+  String pipeline_tools_version = "surge-single-end-ss2"
 
   call GetInputs as prep {
     input:

--- a/adapter_pipelines/ss2_single_end/adapter.wdl
+++ b/adapter_pipelines/ss2_single_end/adapter.wdl
@@ -98,7 +98,6 @@ workflow AdapterSmartSeq2SingleCellUnpaired {
 
   call ss2.SmartSeq2SingleCellUnpaired as analysis {
     input:
-      gtf_file = gtf_file,
       genome_ref_fasta = genome_ref_fasta,
       rrna_intervals = rrna_intervals,
       gene_ref_flat = gene_ref_flat,

--- a/adapter_pipelines/ss2_single_end/adapter.wdl
+++ b/adapter_pipelines/ss2_single_end/adapter.wdl
@@ -81,7 +81,7 @@ workflow AdapterSmartSeq2SingleCellUnpaired {
   Int max_cromwell_retries = 0
   Boolean add_md5s = false
 
-  String pipeline_tools_version = "v0.50.2"
+  String pipeline_tools_version = "v0.51.0"
 
   call GetInputs as prep {
     input:

--- a/adapter_pipelines/ss2_single_end/adapter.wdl
+++ b/adapter_pipelines/ss2_single_end/adapter.wdl
@@ -81,7 +81,7 @@ workflow AdapterSmartSeq2SingleCellUnpaired {
   Int max_cromwell_retries = 0
   Boolean add_md5s = false
 
-  String pipeline_tools_version = "surge-single-end-ss2"
+  String pipeline_tools_version = "v0.51.0"
 
   call GetInputs as prep {
     input:

--- a/adapter_pipelines/ss2_single_end/adapter.wdl
+++ b/adapter_pipelines/ss2_single_end/adapter.wdl
@@ -1,0 +1,207 @@
+import "SmartSeq2SingleSampleUnpaired.wdl" as ss2
+import "submit.wdl" as submit_wdl
+
+
+task GetInputs {
+  String bundle_uuid
+  String bundle_version
+  String dss_url
+  Int? retry_timeout
+  Float? retry_multiplier
+  Int? retry_max_interval
+  Int? individual_request_timeout
+  Boolean record_http
+  String pipeline_tools_version
+
+  command <<<
+    export RECORD_HTTP_REQUESTS="${record_http}"
+    export RETRY_TIMEOUT="${retry_timeout}"
+    export RETRY_MULTIPLIER="${retry_multiplier}"
+    export RETRY_MAX_INTERVAL="${retry_max_interval}"
+    export INDIVIDUAL_REQUEST_TIMEOUT="${individual_request_timeout}"
+
+    # Force the binary layer of the stdout and stderr streams to be unbuffered.
+    python -u <<CODE
+    from pipeline_tools.pipelines.smartseq2 import smartseq2
+
+    smartseq2.create_ss2_se_input_tsv(
+                  "${bundle_uuid}",
+                  "${bundle_version}",
+                  "${dss_url}")
+
+    CODE
+  >>>
+  runtime {
+    docker: "quay.io/humancellatlas/secondary-analysis-pipeline-tools:" + pipeline_tools_version
+  }
+  output {
+    Array[File] http_requests = glob("request_*.txt")
+    Array[File] http_responses = glob("response_*.txt")
+    Object inputs = read_object("inputs.tsv")
+  }
+}
+
+workflow AdapterSmartSeq2SingleCellUnpaired {
+  # variable parameters provided by the notification sent by the data storage service
+  String bundle_uuid
+  String bundle_version
+
+  # fixed parameters
+  File genome_ref_fasta
+  File rrna_intervals
+  File gene_ref_flat
+  File hisat2_ref_index
+  File hisat2_ref_trans_index
+  File rsem_ref_index
+  File hisat2_ref_name
+  File hisat2_ref_trans_name
+  String stranded
+
+  # submission parameters
+  File format_map
+  String dss_url
+  String submit_url
+  String method
+  String schema_url
+  String cromwell_url
+  String analysis_process_schema_version
+  String analysis_protocol_schema_version
+  String analysis_file_version
+  String run_type
+  Int? retry_max_interval
+  Float? retry_multiplier
+  Int? retry_timeout
+  Int? individual_request_timeout
+  String reference_bundle
+
+  # Set runtime environment such as "dev" or "staging" or "prod" so submit task could choose proper docker image to use
+  String runtime_environment
+  # By default, don't record http requests, unless we override in inputs json
+  Boolean record_http = false
+  Int max_cromwell_retries = 0
+  Boolean add_md5s = false
+
+  String pipeline_tools_version = "v0.50.2"
+
+  call GetInputs as prep {
+    input:
+      bundle_uuid = bundle_uuid,
+      bundle_version = bundle_version,
+      dss_url = dss_url,
+      retry_multiplier = retry_multiplier,
+      retry_max_interval = retry_max_interval,
+      retry_timeout = retry_timeout,
+      individual_request_timeout = individual_request_timeout,
+      record_http = record_http,
+      pipeline_tools_version = pipeline_tools_version
+  }
+
+  call ss2.SmartSeq2SingleCell as analysis {
+    input:
+      gtf_file = gtf_file,
+      genome_ref_fasta = genome_ref_fasta,
+      rrna_intervals = rrna_intervals,
+      gene_ref_flat = gene_ref_flat,
+      hisat2_ref_index = hisat2_ref_index,
+      hisat2_ref_trans_index = hisat2_ref_trans_index,
+      rsem_ref_index = rsem_ref_index,
+      hisat2_ref_name = hisat2_ref_name,
+      hisat2_ref_trans_name = hisat2_ref_trans_name,
+      stranded = stranded,
+      sample_name = prep.inputs.sample_id,
+      output_name = prep.inputs.sample_id,
+      fastq = prep.inputs.fastq,
+      max_retries = max_cromwell_retries
+  }
+
+  call submit_wdl.submit {
+    input:
+      inputs = [
+        {
+          "name": "fastq",
+          "value": prep.inputs.fastq
+        },
+        {
+          "name": "sample_name",
+          "value": prep.inputs.sample_id
+        },
+        {
+          "name": "output_name",
+          "value": prep.inputs.sample_id
+        },
+        {
+          "name": "genome_ref_fasta",
+          "value": genome_ref_fasta
+        },
+        {
+          "name": "rrna_intervals",
+          "value": rrna_intervals
+        },
+        {
+          "name": "gene_ref_flat",
+          "value": gene_ref_flat
+        },
+        {
+          "name": "hisat2_ref_index",
+          "value": hisat2_ref_index
+        },
+        {
+          "name": "hisat2_ref_trans_name",
+          "value": hisat2_ref_trans_name
+        },
+        {
+          "name": "rsem_ref_index",
+          "value": rsem_ref_index
+        },
+        {
+          "name": "hisat2_ref_name",
+          "value": hisat2_ref_name
+        },
+         {
+          "name": "hisat2_ref_trans_name",
+          "value": hisat2_ref_trans_name
+        },
+        {
+          "name": "stranded",
+          "value": stranded
+        }
+      ],
+      outputs = flatten(
+        select_all(
+          [[analysis.aligned_bam,
+            analysis.bam_index,
+            analysis.quality_distribution_metrics,
+            analysis.quality_by_cycle_metrics,
+            analysis.bait_bias_summary_metrics,
+            analysis.rna_metrics,
+            analysis.aligned_transcriptome_bam,
+            analysis.rsem_gene_results,
+            analysis.rsem_isoform_results
+           ], analysis.group_results, analysis.zarr_output_files]
+        )
+      ),
+      format_map = format_map,
+      submit_url = submit_url,
+      cromwell_url = cromwell_url,
+      input_bundle_uuid = bundle_uuid,
+      reference_bundle = reference_bundle,
+      run_type = run_type,
+      schema_url = schema_url,
+      analysis_process_schema_version = analysis_process_schema_version,
+      analysis_protocol_schema_version = analysis_protocol_schema_version,
+      analysis_file_version = analysis_file_version,
+      method = method,
+      retry_multiplier = retry_multiplier,
+      retry_max_interval = retry_max_interval,
+      retry_timeout = retry_timeout,
+      individual_request_timeout = individual_request_timeout,
+      runtime_environment = runtime_environment,
+      record_http = record_http,
+      pipeline_tools_version = pipeline_tools_version,
+      add_md5s = add_md5s,
+      max_retries = max_cromwell_retries,
+      pipeline_version = analysis.pipeline_version,
+      # The bam files are by far the largest outputs. The extra 5 GB should easily cover everything else.
+      disk_space = ceil(size(analysis.aligned_bam, "GB") + size(analysis.aligned_transcriptome_bam, "GB") + 5)
+  }
+}

--- a/adapter_pipelines/ss2_single_end/adapter.wdl
+++ b/adapter_pipelines/ss2_single_end/adapter.wdl
@@ -96,7 +96,7 @@ workflow AdapterSmartSeq2SingleCellUnpaired {
       pipeline_tools_version = pipeline_tools_version
   }
 
-  call ss2.SmartSeq2SingleCell as analysis {
+  call ss2.SmartSeq2SingleCellUnpaired as analysis {
     input:
       gtf_file = gtf_file,
       genome_ref_fasta = genome_ref_fasta,

--- a/adapter_pipelines/ss2_single_end/adapter_example_static.json
+++ b/adapter_pipelines/ss2_single_end/adapter_example_static.json
@@ -18,11 +18,12 @@
   "AdapterSmartSeq2SingleCellUnpaired.run_type": "run",
   "AdapterSmartSeq2SingleCellUnpaired.add_md5s": false,
 
-  "AdapterSmartSeq2SingleCellUnpaired.env": "test",
+  "AdapterSmartSeq2SingleCellUnpaired.runtime_environment": "test",
   "AdapterSmartSeq2SingleCellUnpaired.dss_url": "https://dss.integration.data.humancellatlas.org/v1",
   "AdapterSmartSeq2SingleCellUnpaired.schema_url": "https://schema.integration.data.humancellatlas.org/",
   "AdapterSmartSeq2SingleCellUnpaired.submit_url": "https://api.ingest.integration.data.humancellatlas.org/",
   "AdapterSmartSeq2SingleCellUnpaired.max_cromwell_retries": "1",
   "AdapterSmartSeq2SingleCellUnpaired.bundle_uuid": "fff98262-db28-408a-b06d-633d8f5d2cf7",
-  "AdapterSmartSeq2SingleCellUnpaired.bundle_version": "2018-12-03T172048.201761Z"
+  "AdapterSmartSeq2SingleCellUnpaired.bundle_version": "2018-12-03T172048.201761Z",
+  "AdapterSmartSeq2SingleCellUnpaired.cromwell_url": "https://cromwell.caas-prod.broadinstitute.org"
 }

--- a/adapter_pipelines/ss2_single_end/adapter_example_static.json
+++ b/adapter_pipelines/ss2_single_end/adapter_example_static.json
@@ -1,0 +1,20 @@
+{
+  "AdapterSmartSeq2SingleCellUnpaired.hisat2_ref_trans_name": "gencode_v27_trans_rsem",
+  "AdapterSmartSeq2SingleCellUnpaired.rrna_intervals": "gs://hca-dcp-mint-test-data/reference/GRCh38_Gencode/gencode.v27.rRNA.interval_list",
+  "AdapterSmartSeq2SingleCellUnpaired.star_ref_index": "gs://hca-dcp-mint-test-data/reference/GRCh38_Gencode/GRCh38_GencodeV27_Primary.tar",
+  "AdapterSmartSeq2SingleCellUnpaired.hisat2_ref_index": "gs://hca-dcp-mint-test-data/reference/HISAT2/genome_snp_tran.tar.gz",
+  "AdapterSmartSeq2SingleCellUnpaired.genome_ref_fasta": "gs://hca-dcp-mint-test-data/reference/GRCh38_Gencode/GRCh38.primary_assembly.genome.fa",
+  "AdapterSmartSeq2SingleCellUnpaired.hisat2_ref_trans_index": "gs://hca-dcp-mint-test-data/reference/HISAT2/gencode_v27_trans_rsem.tar.gz",
+  "AdapterSmartSeq2SingleCellUnpaired.rsem_ref_index": "gs://hca-dcp-mint-test-data/reference/GRCh38_Gencode/gencode_v27_primary.tar",
+  "AdapterSmartSeq2SingleCellUnpaired.gene_ref_flat": "gs://hca-dcp-mint-test-data/reference/GRCh38_Gencode/GRCh38_gencode.v27.refFlat.txt",
+  "AdapterSmartSeq2SingleCellUnpaired.hisat2_ref_name": "genome_snp_tran",
+  "AdapterSmartSeq2SingleCellUnpaired.stranded":"NONE",
+  "AdapterSmartSeq2SingleCellUnpaired.reference_bundle": "bf51d668-3e14-4843-9bc7-5d676fdf0e01",
+  "AdapterSmartSeq2SingleCellUnpaired.format_map": "gs://hca-dcp-mint-test-data/adapters/file_format_map.json",
+  "AdapterSmartSeq2SingleCellUnpaired.method": "SmartSeq2SingleCell",
+  "AdapterSmartSeq2SingleCellUnpaired.analysis_file_version": "6.0.0",
+  "AdapterSmartSeq2SingleCellUnpaired.analysis_protocol_schema_version": "9.0.0",
+  "AdapterSmartSeq2SingleCellUnpaired.analysis_process_schema_version": "11.0.1",
+  "AdapterSmartSeq2SingleCellUnpaired.run_type": "run",
+  "AdapterSmartSeq2SingleCellUnpaired.add_md5s": false
+}

--- a/adapter_pipelines/ss2_single_end/adapter_example_static.json
+++ b/adapter_pipelines/ss2_single_end/adapter_example_static.json
@@ -16,5 +16,13 @@
   "AdapterSmartSeq2SingleCellUnpaired.analysis_protocol_schema_version": "9.0.0",
   "AdapterSmartSeq2SingleCellUnpaired.analysis_process_schema_version": "11.0.1",
   "AdapterSmartSeq2SingleCellUnpaired.run_type": "run",
-  "AdapterSmartSeq2SingleCellUnpaired.add_md5s": false
+  "AdapterSmartSeq2SingleCellUnpaired.add_md5s": false,
+
+  "AdapterSmartSeq2SingleCellUnpaired.env": "test",
+  "AdapterSmartSeq2SingleCellUnpaired.dss_url": "https://dss.integration.data.humancellatlas.org/v1",
+  "AdapterSmartSeq2SingleCellUnpaired.schema_url": "https://schema.integration.data.humancellatlas.org/",
+  "AdapterSmartSeq2SingleCellUnpaired.submit_url": "https://api.ingest.integration.data.humancellatlas.org/",
+  "AdapterSmartSeq2SingleCellUnpaired.max_cromwell_retries": "1",
+  "AdapterSmartSeq2SingleCellUnpaired.bundle_uuid": "fff98262-db28-408a-b06d-633d8f5d2cf7",
+  "AdapterSmartSeq2SingleCellUnpaired.bundle_version": "2018-12-03T172048.201761Z"
 }

--- a/adapter_pipelines/ss2_single_end/adapter_example_static.json
+++ b/adapter_pipelines/ss2_single_end/adapter_example_static.json
@@ -9,21 +9,12 @@
   "AdapterSmartSeq2SingleCellUnpaired.gene_ref_flat": "gs://hca-dcp-mint-test-data/reference/GRCh38_Gencode/GRCh38_gencode.v27.refFlat.txt",
   "AdapterSmartSeq2SingleCellUnpaired.hisat2_ref_name": "genome_snp_tran",
   "AdapterSmartSeq2SingleCellUnpaired.stranded":"NONE",
-  "AdapterSmartSeq2SingleCellUnpaired.reference_bundle": "bf51d668-3e14-4843-9bc7-5d676fdf0e01",
+  "AdapterSmartSeq2SingleCellUnpaired.reference_bundle": "00000000-0000-0000-0000-000000000000",
   "AdapterSmartSeq2SingleCellUnpaired.format_map": "gs://hca-dcp-mint-test-data/adapters/file_format_map.json",
   "AdapterSmartSeq2SingleCellUnpaired.method": "SmartSeq2SingleCell",
   "AdapterSmartSeq2SingleCellUnpaired.analysis_file_version": "6.0.0",
   "AdapterSmartSeq2SingleCellUnpaired.analysis_protocol_schema_version": "9.0.0",
   "AdapterSmartSeq2SingleCellUnpaired.analysis_process_schema_version": "11.0.1",
   "AdapterSmartSeq2SingleCellUnpaired.run_type": "run",
-  "AdapterSmartSeq2SingleCellUnpaired.add_md5s": false,
-
-  "AdapterSmartSeq2SingleCellUnpaired.runtime_environment": "test",
-  "AdapterSmartSeq2SingleCellUnpaired.dss_url": "https://dss.integration.data.humancellatlas.org/v1",
-  "AdapterSmartSeq2SingleCellUnpaired.schema_url": "https://schema.integration.data.humancellatlas.org/",
-  "AdapterSmartSeq2SingleCellUnpaired.submit_url": "https://api.ingest.integration.data.humancellatlas.org/",
-  "AdapterSmartSeq2SingleCellUnpaired.max_cromwell_retries": "1",
-  "AdapterSmartSeq2SingleCellUnpaired.bundle_uuid": "fff98262-db28-408a-b06d-633d8f5d2cf7",
-  "AdapterSmartSeq2SingleCellUnpaired.bundle_version": "2018-12-03T172048.201761Z",
-  "AdapterSmartSeq2SingleCellUnpaired.cromwell_url": "https://cromwell.caas-prod.broadinstitute.org"
+  "AdapterSmartSeq2SingleCellUnpaired.add_md5s": false
 }

--- a/adapter_pipelines/ss2_single_end/options.json
+++ b/adapter_pipelines/ss2_single_end/options.json
@@ -1,0 +1,5 @@
+{
+  "monitoring_script": "gs://hca-dcp-mint-test-data/accessories/monitoring/smartseq2/monitoring.sh",
+  "read_from_cache": true,
+  "backend": "PAPIv2"
+}

--- a/adapter_pipelines/ss2_single_end/options_no_caching.json
+++ b/adapter_pipelines/ss2_single_end/options_no_caching.json
@@ -1,0 +1,5 @@
+{
+  "monitoring_script": "gs://hca-dcp-mint-test-data/accessories/monitoring/smartseq2/monitor.sh",
+  "read_from_cache":false,
+  "write_to_cache":false
+}

--- a/adapter_pipelines/ss2_single_sample/adapter.wdl
+++ b/adapter_pipelines/ss2_single_sample/adapter.wdl
@@ -81,7 +81,7 @@ workflow AdapterSmartSeq2SingleCell{
   Int max_cromwell_retries = 0
   Boolean add_md5s = false
 
-  String pipeline_tools_version = "v0.50.2"
+  String pipeline_tools_version = "v0.51.0"
 
   call GetInputs as prep {
     input:

--- a/adapter_pipelines/ss2_single_sample/adapter.wdl
+++ b/adapter_pipelines/ss2_single_sample/adapter.wdl
@@ -47,7 +47,6 @@ workflow AdapterSmartSeq2SingleCell{
   String bundle_version
 
   # fixed parameters
-  File gtf_file
   File genome_ref_fasta
   File rrna_intervals
   File gene_ref_flat
@@ -99,7 +98,6 @@ workflow AdapterSmartSeq2SingleCell{
 
   call ss2.SmartSeq2SingleCell as analysis {
     input:
-      gtf_file = gtf_file,
       genome_ref_fasta = genome_ref_fasta,
       rrna_intervals = rrna_intervals,
       gene_ref_flat = gene_ref_flat,
@@ -134,10 +132,6 @@ workflow AdapterSmartSeq2SingleCell{
         {
           "name": "output_name",
           "value": prep.inputs.sample_id
-        },
-        {
-          "name": "gtf_file",
-          "value": gtf_file
         },
         {
           "name": "genome_ref_fasta",

--- a/adapter_pipelines/ss2_single_sample/adapter_example_static.json
+++ b/adapter_pipelines/ss2_single_sample/adapter_example_static.json
@@ -1,5 +1,4 @@
 {
-  "AdapterSmartSeq2SingleCell.gtf_file": "gs://hca-dcp-mint-test-data/reference/GRCh38_Gencode/gencode.v27.primary_assembly.annotation.gtf",
   "AdapterSmartSeq2SingleCell.hisat2_ref_trans_name": "gencode_v27_trans_rsem",
   "AdapterSmartSeq2SingleCell.rrna_intervals": "gs://hca-dcp-mint-test-data/reference/GRCh38_Gencode/gencode.v27.rRNA.interval_list",
   "AdapterSmartSeq2SingleCell.star_ref_index": "gs://hca-dcp-mint-test-data/reference/GRCh38_Gencode/GRCh38_GencodeV27_Primary.tar",

--- a/pipeline_tools/pipelines/smartseq2/smartseq2.py
+++ b/pipeline_tools/pipelines/smartseq2/smartseq2.py
@@ -85,3 +85,87 @@ def _get_content_for_ss2_input_tsv(bundle_uuid, bundle_version, dss_url, http_re
     sample_id = metadata_utils.get_sample_id(primary_bundle)
     fastq_1_url, fastq_2_url = get_urls_to_files_for_ss2(primary_bundle)
     return fastq_1_url, fastq_2_url, sample_id
+
+
+def create_ss2_se_input_tsv(
+    bundle_uuid, bundle_version, dss_url, input_tsv_name='inputs.tsv'
+):
+    """Create TSV of Smart-seq2 inputs.
+
+    Args:
+        bundle_uuid (str): The bundle uuid
+        bundle_version (str): The bundle version
+        dss_url (str): The url for the DCP Data Storage Service
+        input_tsv_name (str): The file name of the input TSV file. By default, it's set to 'inputs.tsv',
+                              which will be consumed by the pipelines.
+
+    Returns:
+        None: this function will write the TSV file of cloud paths for the input files.
+
+    Raises:
+        requests.HTTPError: for 4xx errors or 5xx errors beyond the timeout
+    """
+    fastq_url, sample_id = _get_content_for_ss2_se_input_tsv(
+        bundle_uuid, bundle_version, dss_url, HttpRequests()
+    )
+
+    print('Creating input map')
+    with open(input_tsv_name, 'w') as f:
+        f.write('fastq\tsample_id\n')
+        f.write('{0}\t{1}\n'.format(fastq_url, sample_id))
+    print('Wrote input map to disk.')
+
+
+def get_urls_to_files_for_ss2_se(bundle):
+    """Return the direct urls to the input fastq files for SmartSeq2 pipeline.
+
+    Args:
+        bundle (humancellatlas.data.metadata.Bundle): A Bundle object contains all of the necessary information.
+
+    Returns:
+         tuple: A tuple consisting of the url to the input fastq file
+         respectively.
+    """
+    fastq_url = None
+    sequence_files = bundle.sequencing_output
+
+    for sf in sequence_files:
+        if fastq_url:
+            return fastq_url
+        # In single-end reads, the one fastq is called read1
+        if sf.read_index == 'read1':
+            fastq_url = sf.manifest_entry.url
+    return fastq_url
+
+
+def _get_content_for_ss2_se_input_tsv(bundle_uuid, bundle_version, dss_url, http_requests):
+    """Gather the necessary metadata for the ss2 input tsv.
+
+    Args:
+        bundle_uuid (str): the bundle uuid.
+        bundle_version (str): the bundle version.
+        dss_url (str): the url for the DCP Data Storage Service.
+        http_requests (HttpRequests): the HttpRequests object to use.
+
+    Returns:
+        tuple: tuple of two strings; url for the fastq, sample id
+
+    Raises:
+        requests.HTTPError: on 4xx errors or 5xx errors beyond the timeout
+    """
+
+    print(
+        "Getting bundle manifest for id {0}, version {1}".format(
+            bundle_uuid, bundle_version
+        )
+    )
+    primary_bundle = metadata_utils.get_bundle_metadata(
+        uuid=bundle_uuid,
+        version=bundle_version,
+        dss_url=dss_url,
+        http_requests=http_requests,
+    )
+
+    sample_id = metadata_utils.get_sample_id(primary_bundle)
+    fastq_url = get_urls_to_files_for_ss2_se(primary_bundle)
+    return fastq_url, sample_id

--- a/pipeline_tools/pipelines/smartseq2/smartseq2.py
+++ b/pipeline_tools/pipelines/smartseq2/smartseq2.py
@@ -130,12 +130,9 @@ def get_urls_to_files_for_ss2_se(bundle):
     sequence_files = bundle.sequencing_output
 
     for sf in sequence_files:
-        if fastq_url:
-            return fastq_url
         # In single-end reads, the one fastq is called read1
         if sf.read_index == 'read1':
-            fastq_url = sf.manifest_entry.url
-    return fastq_url
+            return sf.manifest_entry.url
 
 
 def _get_content_for_ss2_se_input_tsv(bundle_uuid, bundle_version, dss_url, http_requests):

--- a/pipeline_tools/pipelines/smartseq2/smartseq2.py
+++ b/pipeline_tools/pipelines/smartseq2/smartseq2.py
@@ -126,7 +126,7 @@ def get_urls_to_files_for_ss2_se(bundle):
          tuple: A tuple consisting of the url to the input fastq file
          respectively.
     """
-    fastq_url = None
+
     sequence_files = bundle.sequencing_output
 
     for sf in sequence_files:

--- a/pipeline_tools/pipelines/smartseq2/smartseq2.py
+++ b/pipeline_tools/pipelines/smartseq2/smartseq2.py
@@ -90,7 +90,7 @@ def _get_content_for_ss2_input_tsv(bundle_uuid, bundle_version, dss_url, http_re
 def create_ss2_se_input_tsv(
     bundle_uuid, bundle_version, dss_url, input_tsv_name='inputs.tsv'
 ):
-    """Create TSV of Smart-seq2 inputs.
+    """Create TSV of Smart-seq2-SingleEnd inputs.
 
     Args:
         bundle_uuid (str): The bundle uuid

--- a/pipeline_tools/pipelines/smartseq2/smartseq2.py
+++ b/pipeline_tools/pipelines/smartseq2/smartseq2.py
@@ -135,7 +135,9 @@ def get_urls_to_files_for_ss2_se(bundle):
             return sf.manifest_entry.url
 
 
-def _get_content_for_ss2_se_input_tsv(bundle_uuid, bundle_version, dss_url, http_requests):
+def _get_content_for_ss2_se_input_tsv(
+    bundle_uuid, bundle_version, dss_url, http_requests
+):
     """Gather the necessary metadata for the ss2 input tsv.
 
     Args:

--- a/pipeline_tools/tests/data/analysis_process.json
+++ b/pipeline_tools/tests/data/analysis_process.json
@@ -24,11 +24,6 @@
       "parameter_value": "4ee53206-80cd-4144-8c75-b62399a7ae99"
     },
     {
-      "checksum": "8778479ae676099e8dbd67d1d4838f53",
-      "parameter_name": "gtf_file",
-      "parameter_value": "fake-url/GRCh38_Gencode/gencode.v27.primary_assembly.annotation.gtf"
-    },
-    {
       "checksum": "49bdb80d21a64dcb16acfc941843356e",
       "parameter_name": "genome_ref_fasta",
       "parameter_value": "fake-url/GRCh38_Gencode/GRCh38.primary_assembly.genome.fa"


### PR DESCRIPTION
### Purpose
Add a pipeline that processes single-end SS2 data.

Also, the SS2 paired end pipeline has a `gtf_file` input, but it doesn't use it. This removes that input from the adapter wdls, and there's a branch of the same name in skylab that removes it from the pipeline itself.