### PR TITLE
Raise http error for 409 responses

### DIFF
--- a/adapter_pipelines/Optimus/adapter.wdl
+++ b/adapter_pipelines/Optimus/adapter.wdl
@@ -139,7 +139,7 @@ workflow AdapterOptimus {
   Int max_cromwell_retries = 0
   Boolean add_md5s = false
 
-  String pipeline_tools_version = "v0.51.0"
+  String pipeline_tools_version = "se-update-retry-logic"
 
   call GetInputs as prep {
     input:

--- a/adapter_pipelines/Optimus/adapter.wdl
+++ b/adapter_pipelines/Optimus/adapter.wdl
@@ -139,7 +139,7 @@ workflow AdapterOptimus {
   Int max_cromwell_retries = 0
   Boolean add_md5s = false
 
-  String pipeline_tools_version = "se-update-retry-logic"
+  String pipeline_tools_version = "v0.51.1"
 
   call GetInputs as prep {
     input:

--- a/adapter_pipelines/cellranger/adapter.wdl
+++ b/adapter_pipelines/cellranger/adapter.wdl
@@ -150,7 +150,7 @@ workflow Adapter10xCount {
   Int max_cromwell_retries = 0
   Boolean add_md5s = false
 
-  String pipeline_tools_version = "se-update-retry-logic"
+  String pipeline_tools_version = "v0.51.1"
 
   call GetInputs {
     input:

--- a/adapter_pipelines/cellranger/adapter.wdl
+++ b/adapter_pipelines/cellranger/adapter.wdl
@@ -150,7 +150,7 @@ workflow Adapter10xCount {
   Int max_cromwell_retries = 0
   Boolean add_md5s = false
 
-  String pipeline_tools_version = "v0.51.0"
+  String pipeline_tools_version = "se-update-retry-logic"
 
   call GetInputs {
     input:

--- a/adapter_pipelines/ss2_single_end/adapter.wdl
+++ b/adapter_pipelines/ss2_single_end/adapter.wdl
@@ -81,7 +81,7 @@ workflow AdapterSmartSeq2SingleCellUnpaired {
   Int max_cromwell_retries = 0
   Boolean add_md5s = false
 
-  String pipeline_tools_version = "se-update-retry-logic"
+  String pipeline_tools_version = "v0.51.1"
 
   call GetInputs as prep {
     input:

--- a/adapter_pipelines/ss2_single_end/adapter.wdl
+++ b/adapter_pipelines/ss2_single_end/adapter.wdl
@@ -81,7 +81,7 @@ workflow AdapterSmartSeq2SingleCellUnpaired {
   Int max_cromwell_retries = 0
   Boolean add_md5s = false
 
-  String pipeline_tools_version = "v0.51.0"
+  String pipeline_tools_version = "se-update-retry-logic"
 
   call GetInputs as prep {
     input:

--- a/pipeline_tools/shared/http_requests.py
+++ b/pipeline_tools/shared/http_requests.py
@@ -333,7 +333,7 @@ class HttpRequests(object):
             check_status(301, 'bar') raises error
         """
         status = response.status_code
-        matches = 200 <= status <= 299 or status == 409
+        matches = 200 <= status <= 299
         if not matches:
             message = 'HTTP status code {0} is not in expected range 2xx. Response: {1}'.format(
                 status, response.text

--- a/pipeline_tools/tests/test_http_requests.py
+++ b/pipeline_tools/tests/test_http_requests.py
@@ -17,6 +17,10 @@ class TestHttpRequests(object):
             HttpRequests.check_status(response)
         with pytest.raises(requests.HTTPError):
             response = requests.Response()
+            response.status_code = 409
+            HttpRequests.check_status(response)
+        with pytest.raises(requests.HTTPError):
+            response = requests.Response()
             response.status_code = 500
             HttpRequests.check_status(response)
         with pytest.raises(requests.HTTPError):
@@ -35,13 +39,6 @@ class TestHttpRequests(object):
         try:
             response = requests.Response()
             response.status_code = 202
-            HttpRequests.check_status(response)
-        except requests.HTTPError as e:
-            pytest.fail(str(e))
-
-        try:
-            response = requests.Response()
-            response.status_code = 409
             HttpRequests.check_status(response)
         except requests.HTTPError as e:
             pytest.fail(str(e))


### PR DESCRIPTION
### Purpose
The input bundle information in the submission envelope is not getting saved because of a race condition in ingest that causes a 409 conflict error. On our side, we can retry the error but it requires a slight change to the retry logic so that an http error is raised for 409 status codes.

### Changes
Raise an error if a response status code is 409 so that tenacity retries the request


### Review Instructions
<!-- Please provide instructions about how should a reviewer test/verify the changes in this PR: -->

- No instructions.
