### PR TITLE
Make confirm submission step "retryable"

### DIFF
--- a/adapter_pipelines/Optimus/adapter.wdl
+++ b/adapter_pipelines/Optimus/adapter.wdl
@@ -139,7 +139,7 @@ workflow AdapterOptimus {
   Int max_cromwell_retries = 0
   Boolean add_md5s = false
 
-  String pipeline_tools_version = "v0.55.0"
+  String pipeline_tools_version = "se-retry-confirm-step"
 
   call GetInputs as prep {
     input:

--- a/adapter_pipelines/Optimus/adapter.wdl
+++ b/adapter_pipelines/Optimus/adapter.wdl
@@ -139,7 +139,7 @@ workflow AdapterOptimus {
   Int max_cromwell_retries = 0
   Boolean add_md5s = false
 
-  String pipeline_tools_version = "se-retry-confirm-step"
+  String pipeline_tools_version = "v0.56.0"
 
   call GetInputs as prep {
     input:

--- a/adapter_pipelines/cellranger/adapter.wdl
+++ b/adapter_pipelines/cellranger/adapter.wdl
@@ -149,7 +149,7 @@ workflow Adapter10xCount {
   Int max_cromwell_retries = 0
   Boolean add_md5s = false
 
-  String pipeline_tools_version = "v0.55.0"
+  String pipeline_tools_version = "se-retry-confirm-step"
 
   call GetInputs {
     input:

--- a/adapter_pipelines/cellranger/adapter.wdl
+++ b/adapter_pipelines/cellranger/adapter.wdl
@@ -149,7 +149,7 @@ workflow Adapter10xCount {
   Int max_cromwell_retries = 0
   Boolean add_md5s = false
 
-  String pipeline_tools_version = "se-retry-confirm-step"
+  String pipeline_tools_version = "v0.56.0"
 
   call GetInputs {
     input:

--- a/adapter_pipelines/ss2_single_end/adapter.wdl
+++ b/adapter_pipelines/ss2_single_end/adapter.wdl
@@ -70,7 +70,7 @@ workflow AdapterSmartSeq2SingleCellUnpaired {
   Int max_cromwell_retries = 0
   Boolean add_md5s = false
 
-  String pipeline_tools_version = "v0.55.0"
+  String pipeline_tools_version = "se-retry-confirm-step"
 
   call GetInputs as prep {
     input:

--- a/adapter_pipelines/ss2_single_end/adapter.wdl
+++ b/adapter_pipelines/ss2_single_end/adapter.wdl
@@ -70,7 +70,7 @@ workflow AdapterSmartSeq2SingleCellUnpaired {
   Int max_cromwell_retries = 0
   Boolean add_md5s = false
 
-  String pipeline_tools_version = "se-retry-confirm-step"
+  String pipeline_tools_version = "v0.56.0"
 
   call GetInputs as prep {
     input:

--- a/adapter_pipelines/ss2_single_sample/adapter.wdl
+++ b/adapter_pipelines/ss2_single_sample/adapter.wdl
@@ -70,7 +70,7 @@ workflow AdapterSmartSeq2SingleCell{
   Int max_cromwell_retries = 0
   Boolean add_md5s = false
 
-  String pipeline_tools_version = "se-retry-confirm-step"
+  String pipeline_tools_version = "v0.56.0"
 
   call GetInputs as prep {
     input:

--- a/adapter_pipelines/ss2_single_sample/adapter.wdl
+++ b/adapter_pipelines/ss2_single_sample/adapter.wdl
@@ -70,7 +70,7 @@ workflow AdapterSmartSeq2SingleCell{
   Int max_cromwell_retries = 0
   Boolean add_md5s = false
 
-  String pipeline_tools_version = "v0.55.0"
+  String pipeline_tools_version = "se-retry-confirm-step"
 
   call GetInputs as prep {
     input:

--- a/pipeline_tools/shared/exceptions.py
+++ b/pipeline_tools/shared/exceptions.py
@@ -1,2 +1,6 @@
 class UnsupportedOrganismException(Exception):
     pass
+
+
+class SubmissionError(Exception):
+    pass

--- a/pipeline_tools/shared/submission/confirm_submission.py
+++ b/pipeline_tools/shared/submission/confirm_submission.py
@@ -4,7 +4,7 @@ import argparse
 from tenacity import retry_if_result, RetryError
 from datetime import datetime
 from pipeline_tools.shared.http_requests import HttpRequests
-from pipeline_tools.shared import auth_utils
+from pipeline_tools.shared import auth_utils, exceptions
 
 
 def wait_for_valid_status(envelope_url, http_requests):
@@ -102,7 +102,7 @@ def main():
         raise ValueError(message)
 
     if status == 'Invalid':
-        raise ValueError('Invalid submission envelope.')
+        raise exceptions.SubmissionError('Invalid submission envelope.')
     elif status == 'Valid':
         confirm(
             args.envelope_url,


### PR DESCRIPTION
### Purpose
The confirm submission task can fail in Cromwell after successfully making the request to confirm the submission. This leads to successful workflows having a failed status, which is difficult to debug. If this task used Cromwell's maxRetries feature, it could re-try the task in these situations. However, confirming an already confirmed submission throws an error, so this behavior needs to be handled first.

### Changes
1. When polling ingest for the submission envelope status, stop polling when the status goes "Valid", "Complete" or "Invalid". 
2. If the status is "Invalid", throw an error. This will allow us to "fail fast" and more easily differentiate timeout issues vs. actual errors with the submission envelope.
3. If the status is "Valid", confirm the submission.

### Review Instructions
~What if a submission is Invalid? If a task fails because the submission is invalid and the time-out limit was reached, the same thing will happen if the task is retried.~ Resolved with the above changes.

Note: After this is merged, the adapter workflow options need to specify a default `maxRetries` runtime parameter > 0 so that this task is retried by Cromwell if it fails