### PR TITLE
Add default maxRetries to Optimus workflows

### DIFF
--- a/adapter_pipelines/Optimus/options.json
+++ b/adapter_pipelines/Optimus/options.json
@@ -1,5 +1,8 @@
 {
   "monitoring_script": "gs://hca-dcp-mint-test-data/accessories/monitoring/optimus/monitoring.sh",
   "read_from_cache": true,
-  "backend": "PAPIv2"
+  "backend": "PAPIv2",
+  "default_runtime_attributes": {
+    "maxRetries": 1
+  }
 }


### PR DESCRIPTION
### Purpose
Add maxRetries to retry PAPIv2 error code 10 issues.

### Changes
Set default maxRetries in Optimus workflow options 