### PR TITLE
Fix getting bundle metadata in prod

### DIFF
--- a/adapter_pipelines/Optimus/adapter.wdl
+++ b/adapter_pipelines/Optimus/adapter.wdl
@@ -138,7 +138,7 @@ workflow AdapterOptimus {
   Boolean record_http = false
   Boolean add_md5s = false
 
-  String pipeline_tools_version = "v0.56.3"
+  String pipeline_tools_version = "v0.56.4"
 
   call GetInputs as prep {
     input:

--- a/adapter_pipelines/cellranger/adapter.wdl
+++ b/adapter_pipelines/cellranger/adapter.wdl
@@ -148,7 +148,7 @@ workflow Adapter10xCount {
   Boolean record_http = false
   Boolean add_md5s = false
 
-  String pipeline_tools_version = "v0.56.3"
+  String pipeline_tools_version = "v0.56.4"
 
   call GetInputs {
     input:

--- a/adapter_pipelines/ss2_single_end/adapter.wdl
+++ b/adapter_pipelines/ss2_single_end/adapter.wdl
@@ -69,7 +69,7 @@ workflow AdapterSmartSeq2SingleCellUnpaired {
   Boolean record_http = false
   Boolean add_md5s = false
 
-  String pipeline_tools_version = "v0.56.3"
+  String pipeline_tools_version = "v0.56.4"
 
   call GetInputs as prep {
     input:

--- a/adapter_pipelines/ss2_single_sample/adapter.wdl
+++ b/adapter_pipelines/ss2_single_sample/adapter.wdl
@@ -69,7 +69,7 @@ workflow AdapterSmartSeq2SingleCell{
   Boolean record_http = false
   Boolean add_md5s = false
 
-  String pipeline_tools_version = "v0.56.3"
+  String pipeline_tools_version = "v0.56.4"
 
   call GetInputs as prep {
     input:

--- a/pipeline_tools/shared/metadata_utils.py
+++ b/pipeline_tools/shared/metadata_utils.py
@@ -17,8 +17,10 @@ def get_bundle_metadata(uuid, version, dss_url, directurls=False):
     Returns:
         humancellatlas.data.metadata.Bundle: A bundle metadata object.
     """
-    dss_environment = dss_url.split('.')[1]
-    client = dss_client(deployment=dss_environment)
+    dss_deployment = dss_url.split('.')[1]
+    if dss_deployment not in ('dev', 'integration', 'staging'):
+        dss_deployment = None  # If none, the production deployment will be used
+    client = dss_client(deployment=dss_deployment)
     version, manifest, metadata_files = download_bundle_metadata(
         client=client, replica='gcp', uuid=uuid, version=version, directurls=directurls
     )


### PR DESCRIPTION
### Purpose
Fixes the dss deployment environment passed into the metadata-api `download_bundle_metadata` function in production, since it does not follow the same url pattern as the other environments.