### PR TITLE
deal with missing lane index

### DIFF
--- a/adapter_pipelines/Optimus/adapter.wdl
+++ b/adapter_pipelines/Optimus/adapter.wdl
@@ -138,7 +138,7 @@ workflow AdapterOptimus {
   Boolean record_http = false
   Boolean add_md5s = false
 
-  String pipeline_tools_version = "v0.56.4"
+  String pipeline_tools_version = "v0.56.5"
 
   call GetInputs as prep {
     input:

--- a/adapter_pipelines/cellranger/adapter.wdl
+++ b/adapter_pipelines/cellranger/adapter.wdl
@@ -148,7 +148,7 @@ workflow Adapter10xCount {
   Boolean record_http = false
   Boolean add_md5s = false
 
-  String pipeline_tools_version = "v0.56.4"
+  String pipeline_tools_version = "v0.56.5"
 
   call GetInputs {
     input:

--- a/adapter_pipelines/ss2_single_end/adapter.wdl
+++ b/adapter_pipelines/ss2_single_end/adapter.wdl
@@ -69,7 +69,7 @@ workflow AdapterSmartSeq2SingleCellUnpaired {
   Boolean record_http = false
   Boolean add_md5s = false
 
-  String pipeline_tools_version = "v0.56.4"
+  String pipeline_tools_version = "v0.56.5"
 
   call GetInputs as prep {
     input:

--- a/adapter_pipelines/ss2_single_sample/adapter.wdl
+++ b/adapter_pipelines/ss2_single_sample/adapter.wdl
@@ -69,7 +69,7 @@ workflow AdapterSmartSeq2SingleCell{
   Boolean record_http = false
   Boolean add_md5s = false
 
-  String pipeline_tools_version = "v0.56.4"
+  String pipeline_tools_version = "v0.56.5"
 
   call GetInputs as prep {
     input:

--- a/pipeline_tools/shared/tenx_utils.py
+++ b/pipeline_tools/shared/tenx_utils.py
@@ -37,7 +37,7 @@ def create_fastq_dict(fastq_files):
                     'There are multiple sets of reads, but no lane index. '
                     'Cannot properly group reads for analysis.'
                 )
-        if lane not in lane_to_fastqs:
+        else:
             lane_to_fastqs[lane] = {}
         lane_to_fastqs[lane][file.read_index] = file.manifest_entry
 

--- a/pipeline_tools/shared/tenx_utils.py
+++ b/pipeline_tools/shared/tenx_utils.py
@@ -29,6 +29,14 @@ def create_fastq_dict(fastq_files):
     lane_to_fastqs = {}
     for file in fastq_files:
         lane = file.lane_index
+        if lane is None:
+            lane = 0
+        if lane in lane_to_fastqs:
+            if file.read_index in lane_to_fastqs[lane]:
+                raise InsufficientLaneInfoError(
+                    'There are multiple sets of reads, but no lane index. '
+                    'Cannot properly group reads for analysis.'
+                )
         if lane not in lane_to_fastqs:
             lane_to_fastqs[lane] = {}
         lane_to_fastqs[lane][file.read_index] = file.manifest_entry
@@ -131,4 +139,8 @@ def validate_lanes(lane_to_fastqs):
 
 
 class LaneMissingFileError(Exception):
+    pass
+
+
+class InsufficientLaneInfoError(Exception):
     pass

--- a/pipeline_tools/tests/shared/test_tenx_utils.py
+++ b/pipeline_tools/tests/shared/test_tenx_utils.py
@@ -108,6 +108,45 @@ def invalid_files_missing_read2():
     return files
 
 
+@pytest.fixture
+def missing_lane_index_one_set_of_reads():
+    files = [
+        BundleFile(
+            'fastq.gz', None, 'read1', ManifestEntry('gs://somewhere/r1.fastq.gz')
+        ),
+        BundleFile(
+            'fastq.gz', None, 'read2', ManifestEntry('gs://somewhere/r2.fastq.gz')
+        ),
+        BundleFile(
+            'fastq.gz', None, 'index1', ManifestEntry('gs://somewhere/i1.fastq.gz')
+        ),
+    ]
+
+
+@pytest.fixture
+def missing_lane_index_multiple_sets_of_reads():
+    files = [
+        BundleFile(
+            'fastq.gz', None, 'read1', ManifestEntry('gs://somewhere/r1.fastq.gz')
+        ),
+        BundleFile(
+            'fastq.gz', None, 'read2', ManifestEntry('gs://somewhere/r2.fastq.gz')
+        ),
+        BundleFile(
+            'fastq.gz', None, 'index1', ManifestEntry('gs://somewhere/i1.fastq.gz')
+        ),
+        BundleFile(
+            'fastq.gz', None, 'read1', ManifestEntry('gs://somewhereelse/r1.fastq.gz')
+        ),
+        BundleFile(
+            'fastq.gz', None, 'read2', ManifestEntry('gs://somewhereelse/r2.fastq.gz')
+        ),
+        BundleFile(
+            'fastq.gz', None, 'index1', ManifestEntry('gs://somewhereelse/i1.fastq.gz')
+        ),
+    ]
+
+
 def test_create_fastq_dict(
     valid_files_with_index,
     valid_files_with_index_dict,
@@ -149,6 +188,19 @@ def test_validate_lanes_accepts_lanes_when_all_indexed(valid_files_with_index):
 def test_validate_lanes_accepts_lanes_when_none_indexed(valid_files_no_index):
     fastq_dict = tenx_utils.create_fastq_dict(valid_files_no_index)
     tenx_utils.validate_lanes(fastq_dict)
+
+
+def test_create_fastq_dict_reindexes_with_zero_when(
+    missing_lane_index_one_set_of_reads
+):
+    fastq_dict = tenx_utils.create_fastq_dict(missing_lane_index_one_set_of_reads)
+    assert 0 in fastq_dict
+    assert None not in fastq_dict
+
+
+def test_create_fastq_dict_raises_error_when(missing_lane_index_multiple_sets_of_reads):
+    with pytest.raises(tenx_utils.InsufficientLaneInfoError):
+        tenx_utils.create_fastq_dict(missing_lane_index_multiple_sets_of_reads)
 
 
 def test_get_fastqs_for_read_index(valid_files_with_index):

--- a/pipeline_tools/tests/shared/test_tenx_utils.py
+++ b/pipeline_tools/tests/shared/test_tenx_utils.py
@@ -121,6 +121,8 @@ def missing_lane_index_one_set_of_reads():
             'fastq.gz', None, 'index1', ManifestEntry('gs://somewhere/i1.fastq.gz')
         ),
     ]
+    r.shuffle(files)
+    return files
 
 
 @pytest.fixture
@@ -145,6 +147,8 @@ def missing_lane_index_multiple_sets_of_reads():
             'fastq.gz', None, 'index1', ManifestEntry('gs://somewhereelse/i1.fastq.gz')
         ),
     ]
+    r.shuffle(files)
+    return files
 
 
 def test_create_fastq_dict(


### PR DESCRIPTION
### Purpose
Until the metadata team adds more information to allow grouping of files, the pipeline should error out when there are files that need to be grouped and insufficient information to do so. It should not error out when there is only one set of reads, and no need for grouping.

[JIRA](https://broadinstitute.atlassian.net/browse/GH-466)
[Related JIRA](https://broadinstitute.atlassian.net/browse/GH-173)

### Changes
<!-- Please list out what major changes were made in this PR to address the issue: -->

- No changes.

### Review Instructions
<!-- Please provide instructions about how should a reviewer test/verify the changes in this PR: -->

- No instructions.
