### PR TITLE
Get Optimus chemistry from bundle metadata

### DIFF
--- a/pipeline_tools/pipelines/optimus/chemistry.py
+++ b/pipeline_tools/pipelines/optimus/chemistry.py
@@ -14,7 +14,7 @@ class Chemistry(Enum):
 class LibraryConstructionMethod(Enum):
 
     """
-    This class maps to the 10x library construction ontology ids:
+    This class maps to library construction ontology ids, e.g:
     https://www.ebi.ac.uk/ols/ontologies/efo/terms?iri=http%3A%2F%2Fwww.ebi.ac.uk%2Fefo%2FEFO_0008995&viewMode=All&siblings=false
     """
 

--- a/pipeline_tools/pipelines/optimus/chemistry.py
+++ b/pipeline_tools/pipelines/optimus/chemistry.py
@@ -20,7 +20,6 @@ class LibraryConstructionMethod(Enum):
 
     tenX_v2 = "EFO:0009310"
     tenX_3_prime_v2 = "EFO:0009899"
-    tenX_5_prime_v2 = "EFO:0009900"
 
     tenX_v3 = "EFO:0009898"
     tenX_3_prime_v3 = "EFO:0009922"

--- a/pipeline_tools/pipelines/optimus/chemistry.py
+++ b/pipeline_tools/pipelines/optimus/chemistry.py
@@ -1,0 +1,27 @@
+from enum import Enum
+
+
+class Chemistry(Enum):
+    """
+    Parameters for 10x chemistry used by the Optimus pipeline:
+    https://github.com/HumanCellAtlas/skylab/blob/optimus_v1.4.0/pipelines/optimus/Optimus.wdl#L39
+    """
+
+    tenX_v2 = "tenX_v2"
+    tenX_v3 = "tenX_v3"
+
+
+class LibraryConstructionMethod(Enum):
+
+    """
+    This class maps to the 10x library construction ontology ids:
+    https://www.ebi.ac.uk/ols/ontologies/efo/terms?iri=http%3A%2F%2Fwww.ebi.ac.uk%2Fefo%2FEFO_0008995&viewMode=All&siblings=false
+    """
+
+    tenX_v2 = "EFO:0009310"
+    tenX_3_prime_v2 = "EFO:0009899"
+    tenX_5_prime_v2 = "EFO:0009900"
+
+    tenX_v3 = "EFO:0009898"
+    tenX_3_prime_v3 = "EFO:0009922"
+    tenX_5_prime_v3 = "EFO:0009921"

--- a/pipeline_tools/pipelines/optimus/optimus.py
+++ b/pipeline_tools/pipelines/optimus/optimus.py
@@ -1,6 +1,10 @@
 from pipeline_tools.shared import metadata_utils
 from pipeline_tools.shared import tenx_utils
 from pipeline_tools.shared.reference_id import ReferenceId
+from pipeline_tools.pipelines.optimus.chemistry import (
+    Chemistry,
+    LibraryConstructionMethod,
+)
 
 
 REFERENCES = {
@@ -15,6 +19,28 @@ REFERENCES = {
         'ref_genome_fasta': 'gs://hca-dcp-analysis-pipelines-reference/alignmentReferences/optimusGencode_Mouse_M21/GRCm38.primary_assembly.genome.fa',
     },
 }
+
+LIBRARY_CONSTRUCTION_METHODS = {
+    Chemistry.tenX_v2.value: [
+        LibraryConstructionMethod.tenX_v2.value,
+        LibraryConstructionMethod.tenX_3_prime_v2.value,
+        LibraryConstructionMethod.tenX_5_prime_v2.value,
+    ],
+    Chemistry.tenX_v3.value: [
+        LibraryConstructionMethod.tenX_v3.value,
+        LibraryConstructionMethod.tenX_3_prime_v3.value,
+        LibraryConstructionMethod.tenX_5_prime_v3.value,
+    ],
+}
+
+
+def get_tenx_chemistry(library_construction_method_ontology):
+    for chemistry in LIBRARY_CONSTRUCTION_METHODS:
+        if (
+            library_construction_method_ontology
+            in LIBRARY_CONSTRUCTION_METHODS[chemistry]
+        ):
+            return chemistry
 
 
 def get_optimus_inputs(primary_bundle):
@@ -132,5 +158,13 @@ def create_optimus_input_tsv(uuid, version, dss_url):
         print(f"Writing {key}.txt")
         with open(f"{key}.txt", 'w') as f:
             f.write(f"{value}")
+
+    library_construction_method = metadata_utils.get_library_construction_method_ontology(
+        primary_bundle
+    )
+    chemistry = get_tenx_chemistry(library_construction_method)
+    print(f'Detected {chemistry} chemistry and writing to chemistry.txt')
+    with open('chemistry.txt', 'w') as f:
+        f.write(f"{chemistry}")
 
     print('Finished writing files')

--- a/pipeline_tools/pipelines/optimus/optimus.py
+++ b/pipeline_tools/pipelines/optimus/optimus.py
@@ -47,12 +47,13 @@ def get_tenx_chemistry(library_construction_method_ontology):
         chemistry (str): The tenX chemistry (either tenxX_v2 or tenX_v3)
 
     """
-    for chemistry in LIBRARY_CONSTRUCTION_METHODS:
-        if (
-            library_construction_method_ontology
-            in LIBRARY_CONSTRUCTION_METHODS[chemistry]
-        ):
-            return chemistry
+    chemistry = None
+    for each in LIBRARY_CONSTRUCTION_METHODS:
+        if library_construction_method_ontology in LIBRARY_CONSTRUCTION_METHODS[each]:
+            chemistry = each
+    if not chemistry:
+        raise tenx_utils.UnsupportedTenXChemistryError('Unsupported tenX chemistry')
+    return chemistry
 
 
 def get_optimus_inputs(primary_bundle):
@@ -131,6 +132,7 @@ def create_optimus_input_tsv(uuid, version, dss_url):
 
     Raises:
         tenx_utils.LaneMissingFileError if any non-optional fastqs are missing
+        tenx_utils.UnsupportedTenXChemistry if get_tenx_chemistry returns None
     """
     print(f"Getting bundle manifest for id {uuid}, version {version}")
     primary_bundle = metadata_utils.get_bundle_metadata(

--- a/pipeline_tools/pipelines/optimus/optimus.py
+++ b/pipeline_tools/pipelines/optimus/optimus.py
@@ -25,12 +25,7 @@ LIBRARY_CONSTRUCTION_METHODS = {
         LibraryConstructionMethod.tenX_v2.value,
         LibraryConstructionMethod.tenX_3_prime_v2.value,
         LibraryConstructionMethod.tenX_5_prime_v2.value,
-    ],
-    Chemistry.tenX_v3.value: [
-        LibraryConstructionMethod.tenX_v3.value,
-        LibraryConstructionMethod.tenX_3_prime_v3.value,
-        LibraryConstructionMethod.tenX_5_prime_v3.value,
-    ],
+    ]
 }
 
 

--- a/pipeline_tools/pipelines/optimus/optimus.py
+++ b/pipeline_tools/pipelines/optimus/optimus.py
@@ -24,7 +24,6 @@ LIBRARY_CONSTRUCTION_METHODS = {
     Chemistry.tenX_v2.value: [
         LibraryConstructionMethod.tenX_v2.value,
         LibraryConstructionMethod.tenX_3_prime_v2.value,
-        LibraryConstructionMethod.tenX_5_prime_v2.value,
     ]
 }
 

--- a/pipeline_tools/pipelines/optimus/optimus.py
+++ b/pipeline_tools/pipelines/optimus/optimus.py
@@ -35,6 +35,18 @@ LIBRARY_CONSTRUCTION_METHODS = {
 
 
 def get_tenx_chemistry(library_construction_method_ontology):
+    """
+    Determine the tenX chemistry that was used based on the given library construction method. For example, if the
+    library construction method is EFO:0009310 (corresponding to LibraryConstructionMethod.tenX_v2.value), then the
+    chemistry is "tenX_v2".
+
+    Args:
+        library_construction_method_ontology (str): ontology id of the library construction method (e.g. "EFO:0009310")
+
+    Returns:
+        chemistry (str): The tenX chemistry (either tenxX_v2 or tenX_v3)
+
+    """
     for chemistry in LIBRARY_CONSTRUCTION_METHODS:
         if (
             library_construction_method_ontology

--- a/pipeline_tools/shared/exceptions.py
+++ b/pipeline_tools/shared/exceptions.py
@@ -2,5 +2,9 @@ class UnsupportedOrganismException(Exception):
     pass
 
 
+class UnsupportedLibraryPrepException(Exception):
+    pass
+
+
 class SubmissionError(Exception):
     pass

--- a/pipeline_tools/shared/metadata_utils.py
+++ b/pipeline_tools/shared/metadata_utils.py
@@ -1,4 +1,8 @@
-from humancellatlas.data.metadata.api import Bundle, CellSuspension
+from humancellatlas.data.metadata.api import (
+    Bundle,
+    CellSuspension,
+    LibraryPreparationProtocol,
+)
 from humancellatlas.data.metadata.helpers.dss import (
     download_bundle_metadata,
     dss_client,
@@ -67,6 +71,18 @@ def get_ncbi_taxon_id(bundle: Bundle):
             'Multiple distinct species detected in bundle.'
         )
     return first_taxon_id
+
+
+def get_library_construction_method_ontology(primary_bundle):
+    library_prep_protocols = [
+        lp
+        for lp in primary_bundle.protocols.values()
+        if isinstance(lp, LibraryPreparationProtocol)
+    ]
+    if len(library_prep_protocols) != 1:
+        raise Exception('Multiple library preparation protocols detected in bundle.')
+    library_prep_protocol = library_prep_protocols[0]
+    return library_prep_protocol.content['library_construction_method']['ontology']
 
 
 def get_hashes_from_file_manifest(file_manifest):

--- a/pipeline_tools/shared/metadata_utils.py
+++ b/pipeline_tools/shared/metadata_utils.py
@@ -90,7 +90,7 @@ def get_library_construction_method_ontology(bundle):
     """
     library_prep_protocols = [
         lp
-        for lp in bundle.protocols.values()
+        for lp in bundle.entities.values()
         if isinstance(lp, LibraryPreparationProtocol)
     ]
     if len(library_prep_protocols) != 1:
@@ -98,7 +98,7 @@ def get_library_construction_method_ontology(bundle):
             'Multiple library preparation protocols detected in bundle.'
         )
     library_prep_protocol = library_prep_protocols[0]
-    return library_prep_protocol.content['library_construction_method']['ontology']
+    return library_prep_protocol.json['library_construction_method']['ontology']
 
 
 def get_hashes_from_file_manifest(file_manifest):

--- a/pipeline_tools/shared/metadata_utils.py
+++ b/pipeline_tools/shared/metadata_utils.py
@@ -90,7 +90,7 @@ def get_library_construction_method_ontology(bundle):
     """
     library_prep_protocols = [
         lp
-        for lp in bundle.entities.values()
+        for lp in bundle.protocols.values()
         if isinstance(lp, LibraryPreparationProtocol)
     ]
     if len(library_prep_protocols) != 1:

--- a/pipeline_tools/shared/metadata_utils.py
+++ b/pipeline_tools/shared/metadata_utils.py
@@ -76,10 +76,21 @@ def get_ncbi_taxon_id(bundle: Bundle):
     return first_taxon_id
 
 
-def get_library_construction_method_ontology(primary_bundle):
+def get_library_construction_method_ontology(bundle):
+    """ Return the library construction method ontology id from the given bundle.
+
+    Args:
+        bundle (humancellatlas.data.metadata.Bundle): A Bundle object contains all of the necessary information.
+
+    Returns:
+        library_construction_method (str): ontology id of the library construction method (e.g. "EFO:0009310")
+
+    Raises:
+        UnsupportedLibraryPrepException: when the bundle contains more than or less than one library preparation protocol file
+    """
     library_prep_protocols = [
         lp
-        for lp in primary_bundle.protocols.values()
+        for lp in bundle.protocols.values()
         if isinstance(lp, LibraryPreparationProtocol)
     ]
     if len(library_prep_protocols) != 1:

--- a/pipeline_tools/shared/metadata_utils.py
+++ b/pipeline_tools/shared/metadata_utils.py
@@ -7,7 +7,10 @@ from humancellatlas.data.metadata.helpers.dss import (
     download_bundle_metadata,
     dss_client,
 )
-from pipeline_tools.shared.exceptions import UnsupportedOrganismException
+from pipeline_tools.shared.exceptions import (
+    UnsupportedOrganismException,
+    UnsupportedLibraryPrepException,
+)
 
 
 def get_bundle_metadata(uuid, version, dss_url, directurls=False):
@@ -80,7 +83,9 @@ def get_library_construction_method_ontology(primary_bundle):
         if isinstance(lp, LibraryPreparationProtocol)
     ]
     if len(library_prep_protocols) != 1:
-        raise Exception('Multiple library preparation protocols detected in bundle.')
+        raise UnsupportedLibraryPrepException(
+            'Multiple library preparation protocols detected in bundle.'
+        )
     library_prep_protocol = library_prep_protocols[0]
     return library_prep_protocol.content['library_construction_method']['ontology']
 

--- a/pipeline_tools/shared/tenx_utils.py
+++ b/pipeline_tools/shared/tenx_utils.py
@@ -144,3 +144,7 @@ class LaneMissingFileError(Exception):
 
 class InsufficientLaneInfoError(Exception):
     pass
+
+
+class UnsupportedTenXChemistryError(Exception):
+    pass

--- a/pipeline_tools/tests/data/metadata/tenx_vx/metadata_files.json
+++ b/pipeline_tools/tests/data/metadata/tenx_vx/metadata_files.json
@@ -211,7 +211,7 @@
           "ontology_label": "polyA RNA",
           "text": "polyA RNA"
         },
-        "library_construction_approach": {
+        "library_construction_method": {
           "ontology": "EFO:0009310",
           "ontology_label": "10X v2 sequencing",
           "text": "10x v2"

--- a/pipeline_tools/tests/pipelines/optimus/test_optimus.py
+++ b/pipeline_tools/tests/pipelines/optimus/test_optimus.py
@@ -135,6 +135,9 @@ class TestOptimus(object):
         os.remove('ref_genome_fasta.txt')
         os.remove('chemistry.txt')
 
+    @mock.patch(
+        'pipeline_tools.shared.metadata_utils.get_library_construction_method_ontology'
+    )
     @mock.patch('pipeline_tools.shared.metadata_utils.get_ncbi_taxon_id')
     @mock.patch('pipeline_tools.shared.metadata_utils.get_bundle_metadata')
     @mock.patch('pipeline_tools.shared.metadata_utils.get_sample_id')
@@ -143,12 +146,16 @@ class TestOptimus(object):
         mock_sample_id,
         mock_bundle,
         mock_ncbi_taxon_id,
+        mock_lib_construction_method,
         test_tenx_bundle_vx,
         test_tenx_bundle_manifest_vx,
     ):
         mock_sample_id.return_value = 'fake_id'
         mock_bundle.return_value = test_tenx_bundle_vx
         mock_ncbi_taxon_id.return_value = ReferenceId.Human.value
+        mock_lib_construction_method.return_value = (
+            optimus.LibraryConstructionMethod.tenX_v2.value
+        )
         with HttpRequestsManager():
             inputs = optimus.get_optimus_inputs_to_hash(
                 uuid='bundle_uuid', version='bundle_version', dss_url='foo_url'
@@ -168,10 +175,13 @@ class TestOptimus(object):
         r1_hashes = f'{read1_manifest.sha1}{read1_manifest.sha256}{read1_manifest.s3_etag}{read1_manifest.crc32c}'
         r2_hashes = f'{read2_manifest.sha1}{read2_manifest.sha256}{read2_manifest.s3_etag}{read2_manifest.crc32c}'
         i1_hashes = f'{index1_manifest.sha1}{index1_manifest.sha256}{index1_manifest.s3_etag}{index1_manifest.crc32c}'
+        expected_chemistry = optimus.Chemistry.tenX_v2.value
+
         assert inputs == (
             'fake_id',
             ReferenceId.Human.value,
             f'{r1_hashes}{r2_hashes}{i1_hashes}',
+            expected_chemistry,
         )
 
     def test_get_tenx_chemistry(self):

--- a/pipeline_tools/tests/pipelines/optimus/test_optimus.py
+++ b/pipeline_tools/tests/pipelines/optimus/test_optimus.py
@@ -7,6 +7,7 @@ from humancellatlas.data.metadata.api import Bundle, ManifestEntry
 
 from pipeline_tools.pipelines.optimus import optimus, chemistry
 from pipeline_tools.shared.reference_id import ReferenceId
+from pipeline_tools.shared.tenx_utils import UnsupportedTenXChemistryError
 from pipeline_tools.tests.http_requests_manager import HttpRequestsManager
 from pathlib import Path
 
@@ -178,6 +179,11 @@ class TestOptimus(object):
         expected_chemistry = chemistry.Chemistry.tenX_v2.value
         tenx_chemistry = optimus.get_tenx_chemistry(ontology_id)
         assert tenx_chemistry == expected_chemistry
+
+    def test_get_tenx_chemistry_raises_error_for_unsupported_values(self):
+        fake_ontology_id = "EFO:0000000"
+        with pytest.raises(UnsupportedTenXChemistryError):
+            tenx_chemistry = optimus.get_tenx_chemistry(fake_ontology_id)
 
 
 def assert_file_contents(actual_file, expected_contents):

--- a/pipeline_tools/tests/shared/test_metadata_utils.py
+++ b/pipeline_tools/tests/shared/test_metadata_utils.py
@@ -140,6 +140,12 @@ class TestMetadataUtils(object):
         ncbi_taxon_id = metadata_utils.get_ncbi_taxon_id(test_ss2_bundle_vx)
         assert ncbi_taxon_id == 9606
 
+    def test_get_library_construction_method_ontology(self, test_tenx_bundle_vx):
+        library_construction_method_ontology = metadata_utils.get_library_construction_method_ontology(
+            test_tenx_bundle_vx
+        )
+        assert library_construction_method_ontology == "EFO:0009310"
+
     def test_get_hashes_from_file_manifest(self, test_fastq_file_manifest):
         file_hashes = metadata_utils.get_hashes_from_file_manifest(
             test_fastq_file_manifest


### PR DESCRIPTION
### Purpose
The newest version of Optimus requires a "chemistry" parameter to determine whether the data is for a 10x v2 or v3 assay, so the adapter pipeline must provide this info to the pipeline. 

### Changes
Get the library construction method ontology from the metadata and use that to determine whether the Optimus chemistry. Then, write the value to a file called "chemistry.txt" so that it can be included with the rest of the outputs of the adapter WDL's prep task.

Note: Right now, this only supports Optimus v2 chemistry to simplify the PR. I will open up a follow-up PR that handles Optimus v3 and updates the input hashing function.

### Review Instructions
- No instructions.
