### PR TITLE
match uuid with regex

### DIFF
--- a/pipeline_tools/shared/submission/get_analysis_workflow_metadata.py
+++ b/pipeline_tools/shared/submission/get_analysis_workflow_metadata.py
@@ -2,6 +2,7 @@ import argparse
 import json
 import google.auth
 import google.auth.transport.requests
+import re
 from pipeline_tools.shared.http_requests import HttpRequests
 
 
@@ -15,9 +16,10 @@ def get_analysis_workflow_id(analysis_output_path):
     Returns:
         workflow_id (str): string giving Cromwell UUID of the workflow.
     """
+    # Get the last match for UUID to ensure it is the subworkflow id
     url = analysis_output_path
-    calls = url.split('/call-')
-    workflow_id = calls[1].split('/')[-1]
+    uuid_regex = r"([a-z0-9]{8}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{12})"
+    workflow_id = re.findall(uuid_regex, url)[-1]
     print('Got analysis workflow UUID: {0}'.format(workflow_id))
     with open('workflow_id.txt', 'w') as f:
         f.write(workflow_id)

--- a/pipeline_tools/tests/shared/submission/test_get_analysis_workflow_metadata.py
+++ b/pipeline_tools/tests/shared/submission/test_get_analysis_workflow_metadata.py
@@ -26,9 +26,14 @@ def test_data():
         )
         analysis_output_path = (
             'gs://broad-dsde-mint-dev-cromwell-execution/cromwell-executions'
-            '/AdapterSmartSeq2SingleCell/adapter_workflow_id/call-analysis/SmartSeq2SingleCell'
-            '/analysis_subworkflow_id/call-qc/RunHisat2Pipeline/qc_workflow_id/call-Hisat2'
-            '/12345_qc.hisat2.met.txt'
+            '/AdapterSmartSeq2SingleCell/adapter0-work-flow-id00-000000000000'
+            '/call-analysis/SmartSeq2SingleCell/analysis-0sub-work-flow-id0000000000'
+            '/call-qc/RunHisat2Pipeline/qc_workflow_id/call-Hisat2/12345_qc.hisat2.met.txt'
+        )
+        terra_analysis_output_path = (
+            'gs://fc-3b6dcfeb-d840-4daf-8d3d-d6e4762ea07d/toplevel-work-flow-id00-000000000000'
+            '/MultiSampleSmartSeq2/0subwork-flow-id00-0000-000000000000'
+            '/call-AggregateLoom/cacheCopy/human_test.loom'
         )
         query_workflow_response_200 = {
             "results": [
@@ -69,9 +74,21 @@ class TestGetAnalysisWorkflowMetadata(object):
             result = get_analysis_workflow_metadata.get_analysis_workflow_id(
                 analysis_output_path
             )
-        expected = 'analysis_subworkflow_id'
+        expected = 'analysis-0sub-work-flow-id0000000000'
         assert result == expected
-        assert current_file_path.read() == 'analysis_subworkflow_id'
+        assert current_file_path.read() == 'analysis-0sub-work-flow-id0000000000'
+
+    def test_get_terra_analysis_workflow_id(self, test_data, tmpdir):
+        current_file_path = tmpdir.join('workflow_id.txt')
+        analysis_output_path = test_data.terra_analysis_output_path
+
+        with tmpdir.as_cwd():  # this stops unittests from writing files and polluting the directory
+            result = get_analysis_workflow_metadata.get_analysis_workflow_id(
+                analysis_output_path
+            )
+        expected = '0subwork-flow-id00-0000-000000000000'
+        assert result == expected
+        assert current_file_path.read() == '0subwork-flow-id00-0000-000000000000'
 
     def test_get_metadata_using_caas(self, requests_mock, test_data, tmpdir):
         current_file_path = tmpdir.join('metadata.json')


### PR DESCRIPTION
### Purpose
Update to `get_analysis_workflow_id` to support analysis output paths from workflows run within Terra, which conform to a slightly different style.

- No issue is linked to this PR.

### Changes
`get_analysis_workflow_id` now relies on a regex matching the UUID style, which grabs the last match from the path. This should ensure that a sub-workflow id is chosen if available, but does not rely on a specific number of matches on `/call-` or specific placement of the UUID within the path.

### Review Instructions
Please make sure that my assumptions on UUID format and path placement are correct.
