### PR TITLE
refactoring input_id and project_stratum_string to file_name_string

### DIFF
--- a/pipeline_tools/shared/submission/create_links.py
+++ b/pipeline_tools/shared/submission/create_links.py
@@ -61,17 +61,16 @@ class LinksFile():
 
     def __init__(
         self,
-        input_id,
         project_id,
         input_uuids,
+        file_name_string,
         output_file_path,
         workspace_version,
         analysis_process_path,
-        analysis_protocol_path,
-            project_stratum_string):
+            analysis_protocol_path):
 
         # Create UUID to save the file as
-        file_prehash = f"{project_stratum_string}{input_id}"
+        file_prehash = f"{file_name_string}"
         subgraph_uuid = format_map.get_uuid5(file_prehash)
 
         # Load the analysis_process json into memory
@@ -86,7 +85,7 @@ class LinksFile():
         with open(output_file_path) as f:
             outputs_dict = json.load(f)
 
-        self.input_id = input_id
+        self.file_name_string = file_name_string
         self.outputs = outputs_dict
         self.project_id = project_id
         self.input_uuids = input_uuids
@@ -96,7 +95,6 @@ class LinksFile():
         self.workspace_version = workspace_version
         self.analysis_process = analysis_process_dict
         self.analysis_protocol = analysis_protocol_dict
-        self.project_stratum_string = project_stratum_string
         self.process_id = analysis_process_dict['process_core']['process_id']
 
     def __links_file__(self):
@@ -165,24 +163,22 @@ class LinksFile():
 
 # Entry point for unit tests
 def test_build_links_file(
-    input_id,
     project_id,
     input_uuids,
+    file_name_string,
     output_file_path,
     workspace_version,
     analysis_process_path,
-    analysis_protocol_path,
-        project_stratum_string):
+        analysis_protocol_path):
 
     test_links_file = LinksFile(
-        input_id,
         project_id,
         input_uuids,
+        file_name_string,
         output_file_path,
         workspace_version,
         analysis_process_path,
-        analysis_protocol_path,
-        project_stratum_string)
+        analysis_protocol_path)
 
     return test_links_file.get_json()
 
@@ -190,24 +186,23 @@ def test_build_links_file(
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument('--project_id', required=True, help='The project ID')
-    parser.add_argument('--input_id', required=True, help='A unique input ID to incorporate into the links UUID.')
     parser.add_argument('--input_uuids', required=True, nargs='+', help='List of UUIDs for the sequencing input files')
     parser.add_argument('--analysis_process_path', required=True, help='Path to the /metadata/analysis_process.json file.')
     parser.add_argument('--analysis_protocol_path', required=True, help='Path to the /metadata/analysis_protocol.json file.')
-    parser.add_argument('--project_stratum_string', required=True, help="Concatenation of the project, library, species, and organ")
     parser.add_argument('--workspace_version', required=True, help='A version (or timestamp) attribute shared across all workflows''within an individual workspace.')
-    parser.add_argument('--output_file_path', required=True, help='Path to the outputs.json file (This is just a json list of the /metadata/analysis_file/*.json files)')
+    parser.add_argument('--output_file_path', required=True, help='Path to the outputs.json file (This is just a json list of the /metadata/analysis_file/*.json files).')
+    parser.add_argument('--file_name_string', required=True, help='Input ID (a unique input ID to incorproate into the links UUID) OR project stratum string (concatenation of the project, library, species, and organ).')
+
     args = parser.parse_args()
 
     links_file = LinksFile(
-        args.input_id,
         args.project_id,
         args.input_uuids,
+        args.file_name_string,
         args.output_file_path,
         args.workspace_version,
         args.analysis_process_path,
-        args.analysis_protocol_path,
-        args.project_stratum_string
+        args.analysis_protocol_path
     )
 
     links_file_json = links_file.get_json()

--- a/pipeline_tools/tests/shared/submission/test_create_links.py
+++ b/pipeline_tools/tests/shared/submission/test_create_links.py
@@ -10,11 +10,10 @@ import pipeline_tools.shared.submission.create_links as cl
 def test_data():
     class Data:
         project_id = "heart_1k_test_v2_S1_L001"
-        input_id = "heart_1k_test_v2_S1_L001"
+        file_name_string = "heart_1k_test_v2_S1_L001"
         input_uuids = ["heart_1k_test_v2_S1_L001_R1_001.fastq.gz", "heart_1k_test_v2_S1_L001_R2_001.fastq.gz"]
         analysis_process_path = f'{Path(os.path.split(__file__)[0]).absolute().parents[1]}/updated-data/staging/metadata/analysis_process/151fe264-c670-4c77-a47c-530ff6b3127b_2021-05-24T12:00:00.000000Z.json'
         analysis_protocol_path = f'{Path(os.path.split(__file__)[0]).absolute().parents[1]}/updated-data/staging/metadata/analysis_protocol/f2cdb4e5-b439-5cdf-ac41-161ff39d5790_2021-05-24T12:00:00.000000Z.json'
-        project_stratum_string = "foo"
         workspace_version = "2021-05-24T12:00:00.000000Z"
         output_file_path = f'{Path(os.path.split(__file__)[0]).absolute().parents[1]}/updated-data/staging/metadata/analysis_file/output.json'
 
@@ -24,14 +23,13 @@ def test_data():
 class TestCreateLinks(object):
     def test_build_links_file(self, test_data):
         links_file_json = cl.test_build_links_file(
-            test_data.input_id,
             test_data.project_id,
             test_data.input_uuids,
+            test_data.file_name_string,
             test_data.output_file_path,
             test_data.workspace_version,
             test_data.analysis_process_path,
-            test_data.analysis_protocol_path,
-            test_data.project_stratum_string
+            test_data.analysis_protocol_path
         )
 
         desired_output_path = f'{Path(os.path.split(__file__)[0]).absolute().parents[1]}/updated-data/links-output.json'

--- a/setup.py
+++ b/setup.py
@@ -29,9 +29,11 @@ setup(
     entry_points={
         'console_scripts': [
             'get-analysis-workflow-metadata=pipeline_tools.shared.submission.get_analysis_workflow_metadata:main',
-            'create-analysis-metadata=pipeline_tools.shared.submission.create_analysis_metadata:main',
             'create-envelope=pipeline_tools.shared.submission.create_envelope:main',
             'create-file-descriptor=pipeline_tools.shared.submission.create_file_descriptor:main',
+            'create-analysis-file=pipeline_tools.shared.submission.create_analysis_file:main',
+            'create-analysis-protocol=pipeline_tools.shared.submission.create_analysis_protocol:main',
+            'create-analysis-process=pipeline_tools.shared.submission.create_analysis_process:main',
             'create-links=pipeline_tools.shared.submission.create_links:main',
             'create-reference-file=pipeline_tools.shared.submission.create_reference_file:main',
             'get-upload-urn=pipeline_tools.shared.submission.get_upload_urn:main',


### PR DESCRIPTION
### Purpose
project_stratum_string and input_id were being passed in, but one was always being left blank. This pr refactors those two variables into one. 


### Changes
project_stratum_string and input_id are being removed, replaced with file_name_string.


### Review Instructions
Run this command and confirm links file is created properly.

`python3 pipeline_tools/shared/submission/create_links.py --project_id heart_1k_test_v2_S1_L001 --input_uuids heart_1k_test_v2_S1_L001_R1_001.fastq.gz heart_1k_test_v2_S1_L001_R2_001.fastq.gz --file_name_string heart_1k_test_v2_S1_L001  --analysis_process_path pipeline_tools/tests/updated-data/staging/metadata/analysis_process/151fe264-c670-4c77-a47c-530ff6b3127b_2021-05-24T12:00:00.000000Z.json --analysis_protocol_path pipeline_tools/tests/updated-data/staging/metadata/analysis_protocol/f2cdb4e5-b439-5cdf-ac41-161ff39d5790_2021-05-24T12:00:00.000000Z.json --workspace_version 2021-05-24T12:00:00.000000Z --output_file_path pipeline_tools/tests/updated-data/staging/metadata/analysis_file/output.json`
