### PR TITLE
[GL-1768] Removing loom_timestamp from create_analysis_process

### DIFF
--- a/pipeline_tools/shared/submission/create_analysis_process.py
+++ b/pipeline_tools/shared/submission/create_analysis_process.py
@@ -80,7 +80,6 @@ class AnalysisProcess():
         workspace_version,
         references=[],
         project_level=False,
-        loom_timestamp="",
             ss2_index=0):
 
         self.ss2_index = ss2_index
@@ -89,7 +88,6 @@ class AnalysisProcess():
         self.reference_files = references
         self.pipeline_type = pipeline_type
         self.project_level = project_level
-        self.loom_timestamp = loom_timestamp
         self.workspace_version = workspace_version
 
     def __analysis_process__(self):
@@ -230,8 +228,7 @@ def test_build_analysis_process(
     pipeline_type,
     workspace_version,
     references=[],
-    project_level=False,
-        loom_timestamp=""):
+        project_level=False):
 
     test_analysis_process = AnalysisProcess(
         input_uuid,
@@ -239,8 +236,7 @@ def test_build_analysis_process(
         pipeline_type,
         workspace_version,
         references,
-        project_level,
-        loom_timestamp
+        project_level
     )
     return test_analysis_process.get_json()
 
@@ -249,7 +245,6 @@ def main():
     parser = argparse.ArgumentParser()
     parser.add_argument("--pipeline_type", required=True, help="Type of pipeline(SS2 or Optimus)")
     parser.add_argument("--workspace_version", required=True, help="Workspace version value i.e. timestamp for workspace")
-    parser.add_argument("--loom_timestamp", required=False, help="The timestamp for the stratified project matrix loom file")
     parser.add_argument("--input_uuid", required=True, help="Input file UUID from the HCA Data Browser (project stratum string for project level)")
     parser.add_argument("--input_file", required=True, help="Path to the JSON obtained from calling Cromwell /metadata for analysis workflow UUID.")
     parser.add_argument("--references", required=False, nargs="+", help="File path for the reference genome fasta")
@@ -265,7 +260,6 @@ def main():
         args.workspace_version,
         args.references,
         args.project_level,
-        args.loom_timestamp,
         args.ss2_index
     )
 

--- a/pipeline_tools/tests/shared/submission/test_create_analysis_process.py
+++ b/pipeline_tools/tests/shared/submission/test_create_analysis_process.py
@@ -11,7 +11,6 @@ def test_data():
         project_level = True
         pipeline_type = "optimus"
         input_uuid = "heart_1k_test_v2_S1_L001"
-        loom_timestamp = "2021-07-26T13:12:24.000000Z"
         workspace_version = "2021-05-24T12:00:00.000000Z"
         references = "c11000b1-2e69-532b-8c72-03dd4c9617d5"
         project_level_pipeline_type = "OptimusPostProcessing"
@@ -341,8 +340,7 @@ class TestCreateProjectLevelAnalysisProcess(object):
             input_file=test_data.project_level_input_file,
             pipeline_type=test_data.pipeline_type,
             workspace_version=test_data.workspace_version,
-            project_level=test_data.project_level,
-            loom_timestamp=test_data.loom_timestamp
+            project_level=test_data.project_level
         )
 
         assert analysis_process.get("analysis_run_type") == "run"


### PR DESCRIPTION
The variable `loom_timestamp` isn't really used anymore for adapters. Removing it here.
